### PR TITLE
ci(blue_krill): lock flake8 version: flake8==4.0.1 pyproject-flake8==…

### DIFF
--- a/.github/workflows/blue-krill.yml
+++ b/.github/workflows/blue-krill.yml
@@ -31,7 +31,7 @@ jobs:
         black sdks/ --config=sdks/blue-krill/pyproject.toml
     - name: Lint with flake8
       run: |
-        pip install pyproject-flake8
+        pip install flake8==4.0.1 pyproject-flake8==0.0.1a4
         pflake8 sdks/ --config=sdks/blue-krill/pyproject.toml
     - name: Lint with mypy
       run: |


### PR DESCRIPTION
锁定 CI check 中 flake8 的版本