### PR TITLE
fix:在使用django setting配置时，encrypt handler动态切换配置

### DIFF
--- a/sdks/blue-krill/blue_krill/encrypt/handler.py
+++ b/sdks/blue-krill/blue_krill/encrypt/handler.py
@@ -41,15 +41,11 @@ class EncryptHandler:
 
     def __init__(self, encrypt_cipher_type: Optional[str] = None, secret_key: Optional[bytes] = None):
         self._encrypt_cipher_type = encrypt_cipher_type
-        self._secret_key = secret_key
+        self.secret_key = secret_key or get_default_secret_key()
 
     @property
     def encrypt_cipher_type(self):
         return self._encrypt_cipher_type or get_default_encrypt_cipher_type()
-
-    @property
-    def secret_key(self):
-        return self._secret_key or get_default_secret_key()
 
     def encrypt(self, text: str) -> str:
         """根据指定加密算法，加密字段"""

--- a/sdks/blue-krill/blue_krill/encrypt/handler.py
+++ b/sdks/blue-krill/blue_krill/encrypt/handler.py
@@ -40,11 +40,13 @@ class EncryptHandler:
     cipher_classes: ClassVar[Dict] = {}
 
     def __init__(self, encrypt_cipher_type: Optional[str] = None, secret_key: Optional[bytes] = None):
-        self.encrypt_cipher_type = encrypt_cipher_type or get_default_encrypt_cipher_type()
-        self.secret_key = secret_key or get_default_secret_key()
+        self.encrypt_cipher_type = encrypt_cipher_type
+        self.secret_key = secret_key
 
     def encrypt(self, text: str) -> str:
         """根据指定加密算法，加密字段"""
+        encrypt_cipher_type = self.encrypt_cipher_type or get_default_encrypt_cipher_type()
+        secret_key = self.secret_key or get_default_secret_key()
         # 已加密则不处理
         for _, cls in self.cipher_classes.items():
             if cls.header.contain_header(text):
@@ -52,18 +54,20 @@ class EncryptHandler:
 
         # 根据加密类型配置选择不同的加密算法
         try:
-            cipher_class = self.cipher_classes[self.encrypt_cipher_type]
+            cipher_class = self.cipher_classes[encrypt_cipher_type]
         except KeyError:
-            raise ValueError(f"Invalid cipher type: {self.encrypt_cipher_type}")
+            raise ValueError(f"Invalid cipher type: {encrypt_cipher_type}")
         else:
-            cipher = cipher_class(self.secret_key)
+            cipher = cipher_class(secret_key)
             return cipher.encrypt(text)
 
     def decrypt(self, encrypted: str) -> str:
+        encrypt_cipher_type = self.encrypt_cipher_type or get_default_encrypt_cipher_type()
+        secret_key = self.secret_key or get_default_secret_key()
         """根据 header 解密"""
         for _, cls in self.cipher_classes.items():
             if cls.header.contain_header(encrypted):
-                cipher = cls(self.secret_key)
+                cipher = cls(secret_key)
                 return cipher.decrypt(encrypted)
         # 若不包含头则直接返回
         return encrypted

--- a/sdks/blue-krill/tests/test_encrypt.py
+++ b/sdks/blue-krill/tests/test_encrypt.py
@@ -59,6 +59,22 @@ class TestEncryptFromDjangoSetting:
             assert encrypt_handler.decrypt(encrypted) == text
 
 
+def test_encrypt_type_switching(self):
+    secret_key = Fernet.generate_key()
+    with override_settings(ENCRYPT_CIPHER_TYPE='FernetCipher', BKKRILL_ENCRYPT_SECRET_KEY=secret_key):
+        encrypt_handler = EncryptHandler()
+        text = random_string(10)
+        encrypted = encrypt_handler.encrypt(text)
+        assert encrypted.startswith("bkcrypt$")
+        assert encrypt_handler.decrypt(encrypted) == text
+
+    with override_settings(ENCRYPT_CIPHER_TYPE='SM4CTR', BKKRILL_ENCRYPT_SECRET_KEY=secret_key):
+        text = random_string(10)
+        encrypted = encrypt_handler.encrypt(text)
+        assert encrypted.startswith("sm4ctr$")
+        assert encrypt_handler.decrypt(encrypted) == text
+
+
 def test_decrypt_legacy():
     encrypted_s = '40Ot6vrbuGI='
     assert legacy_decrypt(encrypted_s, 'a' * 24) == 'foo'

--- a/sdks/blue-krill/tests/test_encrypt.py
+++ b/sdks/blue-krill/tests/test_encrypt.py
@@ -59,7 +59,7 @@ class TestEncryptFromDjangoSetting:
             assert encrypt_handler.decrypt(encrypted) == text
 
 
-def test_encrypt_type_switching():
+def test_switch_encrypt_type():
     secret_key = Fernet.generate_key()
     with override_settings(ENCRYPT_CIPHER_TYPE='FernetCipher', BKKRILL_ENCRYPT_SECRET_KEY=secret_key):
         encrypt_handler = EncryptHandler()

--- a/sdks/blue-krill/tests/test_encrypt.py
+++ b/sdks/blue-krill/tests/test_encrypt.py
@@ -59,7 +59,7 @@ class TestEncryptFromDjangoSetting:
             assert encrypt_handler.decrypt(encrypted) == text
 
 
-def test_encrypt_type_switching(self):
+def test_encrypt_type_switching():
     secret_key = Fernet.generate_key()
     with override_settings(ENCRYPT_CIPHER_TYPE='FernetCipher', BKKRILL_ENCRYPT_SECRET_KEY=secret_key):
         encrypt_handler = EncryptHandler()


### PR DESCRIPTION
在使用django setting配置时，encrypt handler在完成初始化后就不会再修改配置。现在修改为handler配置始终与django setting保持一致，实现动态切换。