### PR TITLE
fix:blue-krill version in pyproject.toml

### DIFF
--- a/sdks/blue-krill/pyproject.toml
+++ b/sdks/blue-krill/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blue-krill"
-version = "2.0.0"
+version = "2.0.1"
 description = "Tools and common packages for blueking paas"
 license = "Apache License 2.0"
 readme = "README.md"


### PR DESCRIPTION
fix:blue-krill version in pyproject.toml