### PR TITLE
(blue-krill 2.0.x) Update: Loosen the version restriction on sub-dep `cryptography`

### DIFF
--- a/sdks/blue-krill/CHANGE.md
+++ b/sdks/blue-krill/CHANGE.md
@@ -1,5 +1,9 @@
 ## Change logs
 
+### 2.0.3
+
+- Loosen the version restriction on sub-dep `cryptography`
+
 ### 2.0.2
 
 - Fix: configure the correct SM4 encryption algorithm
@@ -12,6 +16,10 @@
 
 - Feature: support use pydantic 1.7+ & 2.0+
 - Deprecated: drop support for python 3.6 & 3.7
+
+### 1.2.6
+
+- Loosen the version restriction on sub-dep `cryptography`
 
 ### 1.2.5
 

--- a/sdks/blue-krill/blue_krill/__init__.py
+++ b/sdks/blue-krill/blue_krill/__init__.py
@@ -8,4 +8,4 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
 """
-__version__ = '2.0.0'
+__version__ = "2.0.3"

--- a/sdks/blue-krill/pyproject.toml
+++ b/sdks/blue-krill/pyproject.toml
@@ -1,14 +1,14 @@
 [tool.poetry]
 name = "blue-krill"
-version = "2.0.2"
+version = "2.0.3"
 description = "Tools and common packages for blueking PaaS platform."
 include = ["blue_krill/py.typed"]
 readme = "README.md"
 authors = ["blueking <blueking@tencent.com>"]
 license = "MIT"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
 ]
 
 [project.urls]
@@ -17,8 +17,8 @@ Repository = "https://github.com/TencentBlueKing/bkpaas-python-sdk/"
 
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
-dataclasses = {version = "^0.7", python = ">=3.6.2,<3.7"}
-cryptography = "^3.0.0"
+dataclasses = { version = "^0.7", python = ">=3.6.2,<3.7" }
+cryptography = ">=3.0.0"
 django-environ = "^0.8.1"
 pyjwt = ">=1.7.1"
 requests = "*"


### PR DESCRIPTION
- (blue-krill 2.0.x) Update: Loosen the version restriction on sub-dep `cryptography`