### PR TITLE
(blue-krill 1.2.x)Fix：blue-krill 支持不配置加密算法类型，使用默认类型 Fernet

### DIFF
--- a/sdks/blue-krill/CHANGE.md
+++ b/sdks/blue-krill/CHANGE.md
@@ -1,5 +1,9 @@
 ## Change logs
 
+### 1.2.7
+
+- Fix：支持不配置加密算法类型，使用默认类型 Fernet
+
 ### 1.2.6
 
 - Loosen the version restriction on sub-dep `cryptography`

--- a/sdks/blue-krill/blue_krill/__init__.py
+++ b/sdks/blue-krill/blue_krill/__init__.py
@@ -8,4 +8,4 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
 """
-__version__ = "1.2.6"
+__version__ = "1.2.7"

--- a/sdks/blue-krill/blue_krill/encrypt/utils.py
+++ b/sdks/blue-krill/blue_krill/encrypt/utils.py
@@ -24,8 +24,7 @@ def get_default_secret_key():
 
         return settings.BKKRILL_ENCRYPT_SECRET_KEY
     except ImportError:
-        logger.exception("you should supply a default secret key")
-        raise
+        return None
 
 
 def get_default_encrypt_cipher_type():
@@ -34,10 +33,9 @@ def get_default_encrypt_cipher_type():
     try:
         from django.conf import settings
 
-        return settings.ENCRYPT_CIPHER_TYPE
+        return getattr(settings, 'ENCRYPT_CIPHER_TYPE', 'FernetCipher')
     except ImportError:
-        logger.exception("you should supply a encrypt cipher type")
-        raise
+        return 'FernetCipher'
 
 
 def encrypt_string(s: str, key: Optional[bytes] = None) -> str:

--- a/sdks/blue-krill/pyproject.toml
+++ b/sdks/blue-krill/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blue-krill"
-version = "1.2.6"
+version = "1.2.7"
 description = "Tools and common packages for blueking paas"
 license = "Apache License 2.0"
 readme = "README.md"

--- a/sdks/blue-krill/tests/test_encrypt.py
+++ b/sdks/blue-krill/tests/test_encrypt.py
@@ -58,6 +58,14 @@ class TestEncryptFromDjangoSetting:
             assert encrypted.startswith("sm4ctr")
             assert encrypt_handler.decrypt(encrypted) == text
 
+    def test_default_encrypt(self):
+        with override_settings(BKKRILL_ENCRYPT_SECRET_KEY=Fernet.generate_key()):
+            encrypt_handler = EncryptHandler()
+            text = random_string(10)
+            encrypted = encrypt_handler.encrypt(text)
+            assert encrypted.startswith("bkcrypt$")
+            assert encrypt_handler.decrypt(encrypted) == text
+
 
 def test_decrypt_legacy():
     encrypted_s = '40Ot6vrbuGI='


### PR DESCRIPTION
代码和下面这个一样，只是需要出个 1.2.7 版本的包
https://github.com/TencentBlueKing/bkpaas-python-sdk/pull/164/files