### PR TITLE
tiny: loosen the version restriction on sub-dep `dataclasses`

### DIFF
--- a/sdks/blue-krill/CHANGE.md
+++ b/sdks/blue-krill/CHANGE.md
@@ -1,5 +1,9 @@
 ## Change logs
 
+### 1.2.8
+
+- Loosen the version restriction on sub-dep `dataclasses`
+
 ### 1.2.7
 
 - Fix：支持不配置加密算法类型，使用默认类型 Fernet

--- a/sdks/blue-krill/blue_krill/__init__.py
+++ b/sdks/blue-krill/blue_krill/__init__.py
@@ -8,4 +8,4 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
 """
-__version__ = "1.2.7"
+__version__ = "1.2.8"

--- a/sdks/blue-krill/pyproject.toml
+++ b/sdks/blue-krill/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "blue-krill"
-version = "1.2.7"
+version = "1.2.8"
 description = "Tools and common packages for blueking paas"
 license = "Apache License 2.0"
 readme = "README.md"
@@ -9,7 +9,7 @@ include = ["blue_krill/py.typed"]
 
 [tool.poetry.dependencies]
 python = ">=3.6.2,<3.11"
-dataclasses = { version = "^0.7", python = ">=3.6.2,<3.7" }
+dataclasses = { version = ">=0.7", python = ">=3.6.2,<3.7" }
 cryptography = ">=3.0.0"
 django-environ = "^0.8.1"
 pyjwt = ">=1.7.1"


### PR DESCRIPTION
resolve #179 