### PR TITLE
feat(bkpaas_auth): support get tenant_id via bk_token verify

### DIFF
--- a/sdks/bkpaas-auth/bkpaas_auth/backends.py
+++ b/sdks/bkpaas-auth/bkpaas_auth/backends.py
@@ -2,7 +2,7 @@
 import inspect
 import logging
 import pickle
-from typing import Dict, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -53,13 +53,13 @@ class UniversalAuthBackend:
 
     def authenticate(self, request: HttpRequest, auth_credentials: Dict) -> Optional[Union[User, AnonymousUser]]:
         try:
-            username = self.request_backend.request_username(**auth_credentials)
+            user_info: Dict[str, Any] = self.request_backend.request_user_info(**auth_credentials)
             login_token = generate_random_token()
             token = LoginToken(
                 login_token=login_token,
                 expires_in=bkauth_settings.LOGIN_TOKEN_EXPIRE_IN,
             )
-            token.user_info = UserInfo(username=username)
+            token.user_info = UserInfo(**user_info)
             logger.debug("New login token exchanged by credentials")
         except InvalidTokenCredentialsError:
             logger.warning("authenticate error, invalid credentials given")

--- a/sdks/bkpaas-auth/bkpaas_auth/core/token.py
+++ b/sdks/bkpaas-auth/bkpaas_auth/core/token.py
@@ -4,6 +4,7 @@
 import datetime
 import json
 import logging
+from typing import Any, Dict
 
 from django.utils.timezone import now
 from django.utils.translation import get_language
@@ -21,67 +22,68 @@ logger = logging.getLogger(__name__)
 
 
 class AbstractRequestBackend:
-    def request_username(self, **credentials):
+    def request_user_info(self, **credentials):
         """Get username through credentials"""
 
 
 class TokenRequestBackend(AbstractRequestBackend):
-
     provider_type = ProviderType.BK
 
-    def request_username(self, **credentials):
+    def request_user_info(self, **credentials) -> Dict[str, Any]:
         """Get username through credentials"""
         is_success, resp = http_get(
             bkauth_settings.USER_COOKIE_VERIFY_URL,
             timeout=10,
             headers={
-                'blueking-language': get_language(),
+                "blueking-language": get_language(),
                 "X-Bkapi-Authorization": json.dumps(dict(credentials, **get_app_credentials())),
             },
             params=credentials,
         )
         if not is_success:
-            raise ServiceError('unable to fetch token services')
+            raise ServiceError("unable to fetch token services")
         if not isinstance(resp, dict):
-            raise ValueError(f'response type expect dict, got: {resp}')
+            raise ValueError(f"response type expect dict, got: {resp}")
 
         # API 返回格式为：{"result": true, "code": 0, "message": "", "data": {"bk_username": "xxx"}}
-        code = resp.get('code')
+        code = resp.get("code")
         if code == 0:
-            return resp["data"]["bk_username"]
+            return {"username": resp["data"]["bk_username"], "tenant_id": resp["data"].get("tenant_id")}
 
         logger.debug(
-            f'Get user fail, url: {bkauth_settings.USER_COOKIE_VERIFY_URL}, '
-            f'params: {scrub_data(credentials)}, response: {resp}'
+            f"Get user fail, url: {bkauth_settings.USER_COOKIE_VERIFY_URL}, "
+            f"params: {scrub_data(credentials)}, response: {resp}"
         )
 
         # 用户认证成功，但用户无应用访问权限
         if code == ACCESS_PERMISSION_DENIED_CODE:
-            raise AccessPermissionDenied(resp.get('message'))
+            raise AccessPermissionDenied(resp.get("message"))
 
-        raise InvalidTokenCredentialsError('Invalid credentials given')
+        raise InvalidTokenCredentialsError("Invalid credentials given")
 
 
 class RequestBackend(AbstractRequestBackend):
-
     provider_type = ProviderType.RTX
 
-    def request_username(self, **credentials):
+    def request_user_info(self, **credentials) -> Dict[str, Any]:
         """Get username through credentials"""
         is_success, resp = http_get(bkauth_settings.USER_COOKIE_VERIFY_URL, params=credentials, timeout=10)
         if not is_success:
-            raise ServiceError('unable to fetch token services')
+            raise ServiceError("unable to fetch token services")
         if not isinstance(resp, dict):
-            raise ValueError(f'response type expect dict, got: {resp}')
+            raise ValueError(f"response type expect dict, got: {resp}")
 
         # API 返回格式为：{"msg": "", "data": {"username": "xxx"}, "ret": 0}
-        if resp.get('ret') != 0:
+        if resp.get("ret") != 0:
             logger.debug(
-                f'Get user fail, url: {bkauth_settings.USER_COOKIE_VERIFY_URL}, '
-                f'params: {scrub_data(credentials)}, response: {resp}'
+                f"Get user fail, url: {bkauth_settings.USER_COOKIE_VERIFY_URL}, "
+                f"params: {scrub_data(credentials)}, response: {resp}"
             )
-            raise InvalidTokenCredentialsError('Invalid credentials given')
-        return resp["data"]["username"]
+            raise InvalidTokenCredentialsError("Invalid credentials given")
+
+        return {
+            "username": resp["data"]["username"],
+        }
 
 
 class LoginToken:
@@ -90,15 +92,15 @@ class LoginToken:
     token_timeout_margin = 300
 
     def __init__(self, login_token=None, expires_in=None):
-        assert login_token, 'Must provide token string'
-        assert expires_in, 'Must provide expires_in seconds'
+        assert login_token, "Must provide token string"
+        assert expires_in, "Must provide expires_in seconds"
         self.login_token = login_token
         self.expires_at = now() + datetime.timedelta(seconds=expires_in)
         self.issued_at = now()
-        self.user_info = UserInfo(username='AnonymousUser')
+        self.user_info = UserInfo(username="AnonymousUser")
 
     def __str__(self):
-        return 'token: {} expires_at: {}'.format(self.login_token, self.expires_at)
+        return "token: {} expires_at: {}".format(self.login_token, self.expires_at)
 
     def expired(self):
         return self.expires_at < now()
@@ -118,9 +120,9 @@ def mocked_create_user_from_token(
             ChineseName=username,
         )
     elif provider_type == ProviderType.BK:
-        token.user_info = BkUserInfo(bk_username=username, chname=username, email='', phone='')
+        token.user_info = BkUserInfo(bk_username=username, chname=username, email="", phone="")
     else:
-        raise ValueError('Invalid provider_type given.')
+        raise ValueError("Invalid provider_type given.")
     return create_user_from_token(token)
 
 

--- a/sdks/bkpaas-auth/bkpaas_auth/models.py
+++ b/sdks/bkpaas-auth/bkpaas_auth/models.py
@@ -12,14 +12,14 @@ class AbstractUserWithProvider(models.AbstractBaseUser, models.AnonymousUser):
     """Basic user with provider type"""
 
     bkpaas_user_id = db_models.CharField(primary_key=True, max_length=255)
-    USERNAME_FIELD = 'bkpaas_user_id'
-    USERINFO_FIELDS = ('nickname', 'chinese_name', 'avatar_url', 'email', 'phone')
+    USERNAME_FIELD = "bkpaas_user_id"
+    USERINFO_FIELDS = ("tenant_id", "nickname", "chinese_name", "avatar_url", "email", "phone")
 
     def __init__(self, provider_type, username):
         if not provider_type:
-            self.bkpaas_user_id = '-1'
+            self.bkpaas_user_id = "-1"
         elif provider_type not in ProviderType:
-            raise ValueError('Invalid provider_type given!')
+            raise ValueError("Invalid provider_type given!")
         else:
             self.bkpaas_user_id = user_id_encoder.encode(provider_type, username)
 
@@ -64,7 +64,7 @@ class AbstractUserWithProvider(models.AbstractBaseUser, models.AnonymousUser):
 
     class Meta:
         abstract = True
-        app_label = 'bkpaas_auth'
+        app_label = "bkpaas_auth"
 
 
 class BasicUser(AbstractUserWithProvider):
@@ -106,4 +106,4 @@ class DatabaseUser(AbstractUserWithProvider):
         return obj
 
     class Meta:
-        app_label = 'bkpaas_auth'
+        app_label = "bkpaas_auth"


### PR DESCRIPTION
网关测试需要，还没实地验证，改动不多；
待验证

------

多租户环境，没有bk-esb，所以原先 地址将不可用

```python
    BKAUTH_USER_COOKIE_VERIFY_URL = f"{BK_COMPONENT_API_INNER_URL}/api/c/compapi/v2/bk_login/is_login/"
    BKAUTH_TOKEN_USER_INFO_ENDPOINT = f"{BK_COMPONENT_API_INNER_URL}/api/c/compapi/v2/bk_login/get_user/"
```

需要换成 bklogin 网关 地址

```python
    # https://bkapi.bk-tenant-dev.woa.com/api/bk-login
    BKAUTH_USER_COOKIE_VERIFY_URL = (
        BK_API_URL_TMPL.format(api_name="bk-login") + "/prod/login/api/v3/open/bk-tokens/verify/"
    )
    # FIXME: there got no endpoint for get user info in multi-tenant mode env
    BKAUTH_TOKEN_USER_INFO_ENDPOINT = f"{BK_COMPONENT_API_INNER_URL}/api/c/compapi/v2/bk_login/get_user/"
```

登录服务似乎只用到了 `BKAUTH_USER_COOKIE_VERIFY_URL`, 

```json
{
    "data": {
        "bk_username": "5461b239-5ef2-4c81-a682-5907dbd5f394",
        "tenant_id": "system"
    }
}
```


多租户已经没有 get_user这个接口了（这个在什么场景下会用到？ 拿bk_username获取用户信息，原先是bk-esb封装的）




