### PR TITLE
feat(apigw-manager): 补充 MCP Server 同步接口新增字段

### DIFF
--- a/sdks/apigw-manager/docs/sync_apigateway.md
+++ b/sdks/apigw-manager/docs/sync_apigateway.md
@@ -102,20 +102,34 @@ stages:
               weight: 100
 #  同步 MCP Server 相关配置
 #    mcp_servers:
-#      - name: "mcp_server1",
+#      - name: "mcp_server1"
+#        # MCP Server 中文名/显示名称
+#        title: "MCP Server 示例"
 #        description: "mcp-server demo"
-#        labels: 
+#        labels:
 #          - "test"
 #        # 添加的tool对应的资源名称
 #        resource_names:
 #          - resource1
+#        # 工具名称列表，默认等于 resource_names；如需重命名资源可设置此字段，长度必须与 resource_names 一致，且不能重复
+#        tool_names:
+#          - tool1
 #        # 是否公开
 #        is_public: true
 #        # 1: 开启,0: 停止; 默认是开启
 #        status: 1
+#        # MCP 协议类型: sse（默认）、streamable_http
+#        protocol_type: "sse"
 #        # 授权的应用
 #        target_app_codes:
 #          - "bk_app_code1"
+#        # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用进行授权
+#        oauth2_public_client_enabled: false
+#        # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息
+#        raw_response_enabled: false
+#        # MCP Server 分类名称列表，支持的分类：Uncategorized, Official, Featured, Monitoring, ConfigManagement, DevOps, Emergency, Database, Automation, Observability, Security, ResourceOptimize, ChaosEngineering, Network
+#        category_names:
+#          - "Official"
 ```
 
 > 📢 注意：如果之前接入过的，建议将 spec_version 改成 2，并将原先 `stage:{}`改成 `stages: []`
@@ -183,19 +197,33 @@ stages:
     #  同步 MCP Server 相关配置
     # mcp_servers:
     #  - name: "mcp_server1"
+    #    # MCP Server 中文名/显示名称
+    #    title: "MCP Server 示例"
     #    description: "mcp-server demo"
-    #    labels: 
+    #    labels:
     #      - "test"
     #    # 添加的tool对应的资源名称
     #    resource_names:
     #      - resource1
+    #    # 工具名称列表，默认等于 resource_names；如需重命名资源可设置此字段，长度必须与 resource_names 一致，且不能重复
+    #    tool_names:
+    #      - tool1
     #    # 是否公开
     #    is_public: true
     #    # 1: 开启,0: 停止；默认是开启
     #    status: 1
+    #    # MCP 协议类型: sse（默认）、streamable_http
+    #    protocol_type: "sse"
     #    # 授权的应用
-    #     target_app_codes:
-    #       - "bk_app_code1"
+    #    target_app_codes:
+    #      - "bk_app_code1"
+    #    # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用进行授权
+    #    oauth2_public_client_enabled: false
+    #    # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息
+    #    raw_response_enabled: false
+    #    # MCP Server 分类名称列表，支持的分类：Uncategorized, Official, Featured, Monitoring, ConfigManagement, DevOps, Emergency, Database, Automation, Observability, Security, ResourceOptimize, ChaosEngineering, Network
+    #    category_names:
+    #      - "Official"
 
     # 环境插件配置
     # plugin_configs:

--- a/sdks/apigw-manager/examples/chart/use-configmap/files/support-files/definition.yaml
+++ b/sdks/apigw-manager/examples/chart/use-configmap/files/support-files/definition.yaml
@@ -38,6 +38,9 @@ stages:
     #     # 添加的 tool 对应的资源名称
     #     resource_names:
     #       - resource1
+    #     # 工具名称列表，默认等于 resource_names；如需重命名资源可设置此字段，长度必须与 resource_names 一致，且不能重复
+    #     tool_names:
+    #       - tool1
     #     # 是否公开
     #     is_public: true
     #     # 1: 开启, 0: 停止; 默认是开启
@@ -47,6 +50,13 @@ stages:
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用进行授权
+    #     oauth2_public_client_enabled: false
+    #     # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息
+    #     raw_response_enabled: false
+    #     # MCP Server 分类名称列表，支持的分类：Uncategorized, Official, Featured, Monitoring, ConfigManagement, DevOps, Emergency, Database, Automation, Observability, Security, ResourceOptimize, ChaosEngineering, Network
+    #     category_names:
+    #       - "Official"
 
     # 环境插件配置
     # plugin_configs:

--- a/sdks/apigw-manager/examples/chart/use-custom-docker-image/my-apigw-manager/support-files/definition.yaml
+++ b/sdks/apigw-manager/examples/chart/use-custom-docker-image/my-apigw-manager/support-files/definition.yaml
@@ -38,6 +38,9 @@ stages:
     #     # 添加的 tool 对应的资源名称
     #     resource_names:
     #       - resource1
+    #     # 工具名称列表，默认等于 resource_names；如需重命名资源可设置此字段，长度必须与 resource_names 一致，且不能重复
+    #     tool_names:
+    #       - tool1
     #     # 是否公开
     #     is_public: true
     #     # 1: 开启, 0: 停止; 默认是开启
@@ -47,6 +50,13 @@ stages:
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用进行授权
+    #     oauth2_public_client_enabled: false
+    #     # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息
+    #     raw_response_enabled: false
+    #     # MCP Server 分类名称列表，支持的分类：Uncategorized, Official, Featured, Monitoring, ConfigManagement, DevOps, Emergency, Database, Automation, Observability, Security, ResourceOptimize, ChaosEngineering, Network
+    #     category_names:
+    #       - "Official"
 
     # 环境插件配置
     # plugin_configs:

--- a/sdks/apigw-manager/examples/django/use-custom-script/support-files/definition.yaml
+++ b/sdks/apigw-manager/examples/django/use-custom-script/support-files/definition.yaml
@@ -38,6 +38,9 @@ stages:
     #     # 添加的 tool 对应的资源名称
     #     resource_names:
     #       - resource1
+    #     # 工具名称列表，默认等于 resource_names；如需重命名资源可设置此字段，长度必须与 resource_names 一致，且不能重复
+    #     tool_names:
+    #       - tool1
     #     # 是否公开
     #     is_public: true
     #     # 1: 开启, 0: 停止; 默认是开启
@@ -47,6 +50,13 @@ stages:
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用进行授权
+    #     oauth2_public_client_enabled: false
+    #     # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息
+    #     raw_response_enabled: false
+    #     # MCP Server 分类名称列表，支持的分类：Uncategorized, Official, Featured, Monitoring, ConfigManagement, DevOps, Emergency, Database, Automation, Observability, Security, ResourceOptimize, ChaosEngineering, Network
+    #     category_names:
+    #       - "Official"
 
 # 资源文档
 # 资源文档的目录格式样例如下，en 为英文文档，zh 为中文文档：

--- a/sdks/apigw-manager/src/apigw_manager/drf/management/commands/data/definition.yaml
+++ b/sdks/apigw-manager/src/apigw_manager/drf/management/commands/data/definition.yaml
@@ -73,9 +73,15 @@ stages:
           {% endfor %}
         {% endif %}
         resource_names:
-          {% for resource in mcp_server.tools %}
+          {% for resource in mcp_server.resource_names %}
           - "{{ resource }}"
           {% endfor %}
+        {% if mcp_server.tool_names %}
+        tool_names:
+          {% for tool in mcp_server.tool_names %}
+          - "{{ tool }}"
+          {% endfor %}
+        {% endif %}
         is_public: {{ mcp_server.is_public }}
         protocol_type: "{{ mcp_server.protocol_type }}"
         status: {{ mcp_server.status }}
@@ -83,6 +89,18 @@ stages:
         target_app_codes:
           {% for app_code in mcp_server.target_app_codes %}
           - "{{ app_code }}"
+          {% endfor %}
+        {% endif %}
+        {% if mcp_server.oauth2_public_client_enabled is not none %}
+        oauth2_public_client_enabled: {{ mcp_server.oauth2_public_client_enabled }}
+        {% endif %}
+        {% if mcp_server.raw_response_enabled is not none %}
+        raw_response_enabled: {{ mcp_server.raw_response_enabled }}
+        {% endif %}
+        {% if mcp_server.category_names %}
+        category_names:
+          {% for category in mcp_server.category_names %}
+          - "{{ category }}"
           {% endfor %}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## 变更说明

根据 [API 文档](https://github.com/TencentBlueKing/blueking-apigateway/blob/master/src/dashboard/apigateway/apigateway/data/apidocs/zh/v2_sync_stage_mcp_servers.md) 补充 MCP Server 同步接口的新增字段。

### 新增字段

| 字段 | 说明 |
|------|------|
| tool_names | 工具名称列表，默认等于 resource_names；如需重命名资源可设置此字段，长度必须与 resource_names 一致，且不能重复 |
| oauth2_public_client_enabled | 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用进行授权 |
| raw_response_enabled | 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息 |
| category_names | MCP Server 分类名称列表，支持的分类：Uncategorized, Official, Featured, Monitoring, ConfigManagement, DevOps, Emergency, Database, Automation, Observability, Security, ResourceOptimize, ChaosEngineering, Network |

### 改动内容

- docs/sync_apigateway.md: 更新 mcp_servers 配置样例，补充新增字段说明
- src/apigw_manager/drf/management/commands/data/definition.yaml: 更新模板支持新增字段，修复 tools -> resource_names 字段名
- examples/: 更新 3 个 definition.yaml 样例，补充新增字段配置示例