### PR TITLE
test(drf): cover YAML generation commands

### DIFF
--- a/sdks/apigw-manager/src/apigw_manager/drf/management/commands/generate_definition_yaml.py
+++ b/sdks/apigw-manager/src/apigw_manager/drf/management/commands/generate_definition_yaml.py
@@ -17,7 +17,7 @@ import re
 import shutil
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.template import Template, Context, context
 from django.template.loader import render_to_string
 from drf_spectacular.renderers import OpenApiYamlRenderer
@@ -49,8 +49,24 @@ class Command(BaseCommand):
         self.stdout.write(f"will generate {definition_path} from {source_file}")
         # 如果启用了MCP服务器，则需要生成 mcp_servers 配置
         if hasattr(settings, "BK_APIGW_STAGE_ENABLE_MCP_SERVERS") and settings.BK_APIGW_STAGE_ENABLE_MCP_SERVERS:
+            if not hasattr(settings, "BK_APIGW_STAGE_MCP_SERVERS"):
+                raise CommandError("BK_APIGW_STAGE_MCP_SERVERS must be configured when MCP servers are enabled")
+            if not isinstance(settings.BK_APIGW_STAGE_MCP_SERVERS, list):
+                raise CommandError("BK_APIGW_STAGE_MCP_SERVERS must be a list")
+            if not hasattr(spectacular_settings.POSTPROCESSING_HOOKS, "clear"):
+                raise CommandError("spectacular_settings.POSTPROCESSING_HOOKS must support clear()")
+            if not hasattr(spectacular_settings.POSTPROCESSING_HOOKS, "append"):
+                raise CommandError("spectacular_settings.POSTPROCESSING_HOOKS must support append()")
+            if not callable(spectacular_settings.DEFAULT_GENERATOR_CLASS):
+                raise CommandError("spectacular_settings.DEFAULT_GENERATOR_CLASS must be callable")
+
             for mcp_server in settings.BK_APIGW_STAGE_MCP_SERVERS:
+                if not hasattr(mcp_server, "get") or not hasattr(mcp_server, "__setitem__"):
+                    raise CommandError("BK_APIGW_STAGE_MCP_SERVERS items must be dict-like")
                 mcp_server_tools = mcp_server.get("tools", [])
+                if not isinstance(mcp_server_tools, list):
+                    raise CommandError("BK_APIGW_STAGE_MCP_SERVERS['tools'] must be a list")
+
                 spectacular_settings.POSTPROCESSING_HOOKS.clear()
                 spectacular_settings.POSTPROCESSING_HOOKS.append(
                     post_process_mcp_server_config(mcp_server_tools, delete_mcp_flag=False))

--- a/sdks/apigw-manager/tests/apigw_manager/drf/management/commands/test_generate_definition_yaml.py
+++ b/sdks/apigw-manager/tests/apigw_manager/drf/management/commands/test_generate_definition_yaml.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-蓝鲸 PaaS 平台(BlueKing-PaaS) available.
+# Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://opensource.org/licenses/MIT
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from apigw_manager.drf.management.commands.generate_definition_yaml import Command
+
+
+class AppendOnlyHooks:
+    def __init__(self):
+        self.values = []
+
+    def append(self, value):
+        self.values.append(value)
+
+
+class TestCommand:
+    @patch("apigw_manager.drf.management.commands.generate_definition_yaml.shutil.copyfile")
+    def test_handle_copies_template_without_render(self, mocked_copyfile, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=False,
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            Command().handle(render=False)
+
+        mocked_copyfile.assert_called_once()
+        assert mocked_copyfile.call_args.args[1] == tmp_path / "definition.yaml"
+
+    @patch("apigw_manager.drf.management.commands.generate_definition_yaml.open", new_callable=mock_open)
+    def test_handle_renders_template(self, mocked_open, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=False,
+            BK_APIGW_RELEASE_VERSION="1.0.0",
+        )
+        mocked_open.return_value.read.return_value = "version: {{ settings.BK_APIGW_RELEASE_VERSION }}\n\n"
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            Command().handle(render=True)
+
+        mocked_open.assert_any_call(tmp_path / "definition.yaml", "w")
+        mocked_open().write.assert_called_once_with("version: 1.0.0")
+
+    @patch("apigw_manager.drf.management.commands.generate_definition_yaml.shutil.copyfile")
+    @patch("apigw_manager.drf.management.commands.generate_definition_yaml.OpenApiYamlRenderer")
+    def test_handle_fills_mcp_server_tools(self, mocked_renderer_cls, mocked_copyfile, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=True,
+            BK_APIGW_STAGE_MCP_SERVERS=[{"tools": []}],
+        )
+        patched_spectacular_settings = SimpleNamespace(POSTPROCESSING_HOOKS=[], DEFAULT_GENERATOR_CLASS=None)
+
+        class HookRunningGenerator:
+            def get_schema(self, request, public):
+                schema = {
+                    "paths": {
+                        "/api/v1/with-params": {
+                            "get": {
+                                "operationId": "withParams",
+                                "parameters": [{"name": "id"}],
+                                "x-bk-apigateway-resource": {"enableMcp": True},
+                            }
+                        },
+                        "/api/v1/no-schema": {
+                            "post": {
+                                "operationId": "noSchema",
+                                "x-bk-apigateway-resource": {"enableMcp": True, "noneSchema": True},
+                            }
+                        },
+                    }
+                }
+                for hook in patched_spectacular_settings.POSTPROCESSING_HOOKS:
+                    schema = hook(schema, self, request, public)
+                return schema
+
+        patched_spectacular_settings.DEFAULT_GENERATOR_CLASS = HookRunningGenerator
+        mocked_renderer_cls.return_value = Mock()
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_definition_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                Command().handle(render=False)
+
+        assert patched_settings.BK_APIGW_STAGE_MCP_SERVERS[0]["tools"] == ["withParams", "noSchema"]
+        mocked_copyfile.assert_called_once()
+        mocked_renderer_cls.return_value.render.assert_called_once()
+
+    def test_handle_raises_command_error_without_mcp_servers(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=True,
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=[],
+            DEFAULT_GENERATOR_CLASS=lambda: Mock(),
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_definition_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(CommandError, match="BK_APIGW_STAGE_MCP_SERVERS"):
+                    Command().handle(render=False)
+
+    def test_handle_raises_command_error_with_invalid_mcp_server_tools(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=True,
+            BK_APIGW_STAGE_MCP_SERVERS=[{"tools": "not-a-list"}],
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=[],
+            DEFAULT_GENERATOR_CLASS=lambda: Mock(),
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_definition_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(CommandError, match=r"\['tools'\] must be a list"):
+                    Command().handle(render=False)
+
+    def test_handle_raises_command_error_with_invalid_mcp_server_item(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=True,
+            BK_APIGW_STAGE_MCP_SERVERS=["not-a-dict"],
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=[],
+            DEFAULT_GENERATOR_CLASS=lambda: Mock(),
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_definition_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(CommandError, match="items must be dict-like"):
+                    Command().handle(render=False)
+
+    def test_handle_raises_command_error_with_invalid_hooks(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=True,
+            BK_APIGW_STAGE_MCP_SERVERS=[{}],
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=AppendOnlyHooks(),
+            DEFAULT_GENERATOR_CLASS=lambda: Mock(),
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_definition_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(CommandError, match=r"clear\(\)"):
+                    Command().handle(render=False)
+
+    def test_handle_raises_command_error_with_invalid_generator_class(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_ENABLE_MCP_SERVERS=True,
+            BK_APIGW_STAGE_MCP_SERVERS=[{}],
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=[],
+            DEFAULT_GENERATOR_CLASS=None,
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_definition_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_definition_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(CommandError, match="DEFAULT_GENERATOR_CLASS"):
+                    Command().handle(render=False)

--- a/sdks/apigw-manager/tests/apigw_manager/drf/management/commands/test_generate_resources_yaml.py
+++ b/sdks/apigw-manager/tests/apigw_manager/drf/management/commands/test_generate_resources_yaml.py
@@ -7,11 +7,17 @@
 # an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
 
-from unittest.mock import Mock
+import argparse
+from types import SimpleNamespace
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
+
 from apigw_manager.drf.management.commands.generate_resources_yaml import (
+    Command,
+    SchemaValidationError,
     post_process_inject_method_and_path,
+    post_process_mcp_server_config,
     post_process_only_keep_the_apis_with_specified_tags,
 )
 
@@ -114,3 +120,242 @@ class TestPostProcess:
                 },
             }
         }
+
+    def test_post_process_mcp_server_config_no_paths(self):
+        f = post_process_mcp_server_config([], delete_mcp_flag=True)
+        result = {"hello": "world"}
+
+        assert f(result, Mock(), Mock(), Mock()) == result
+
+    def test_post_process_mcp_server_config_auto_collect_tools(self):
+        mcp_server_tools = []
+        f = post_process_mcp_server_config(mcp_server_tools, delete_mcp_flag=True)
+        result = {
+            "paths": {
+                "/api/v1/with-params": {
+                    "get": {
+                        "operationId": "withParams",
+                        "parameters": [{"name": "id"}],
+                        "x-bk-apigateway-resource": {"enableMcp": True},
+                    }
+                },
+                "/api/v1/no-schema": {
+                    "post": {
+                        "operationId": "noSchema",
+                        "x-bk-apigateway-resource": {"enableMcp": True, "noneSchema": True},
+                    }
+                },
+            }
+        }
+
+        data = f(result, Mock(), Mock(), Mock())
+
+        assert mcp_server_tools == ["withParams", "noSchema"]
+        assert data["paths"]["/api/v1/with-params"]["get"]["x-bk-apigateway-resource"] == {}
+        assert data["paths"]["/api/v1/no-schema"]["post"]["x-bk-apigateway-resource"] == {"noneSchema": True}
+
+    def test_post_process_mcp_server_config_raises_for_missing_schema(self):
+        f = post_process_mcp_server_config([], delete_mcp_flag=False)
+        result = {
+            "paths": {
+                "/api/v1/no-schema": {
+                    "get": {
+                        "operationId": "noSchema",
+                        "x-bk-apigateway-resource": {"enableMcp": True},
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(Exception, match="noneSchema=True"):
+            f(result, Mock(), Mock(), Mock())
+
+    def test_post_process_mcp_server_config_accepts_specified_tool(self):
+        f = post_process_mcp_server_config(["createThing"], delete_mcp_flag=False)
+        result = {
+            "paths": {
+                "/api/v1/things": {
+                    "post": {
+                        "operationId": "createThing",
+                        "requestBody": {"content": {}},
+                        "x-bk-apigateway-resource": {"enableMcp": True},
+                    }
+                }
+            }
+        }
+
+        assert f(result, Mock(), Mock(), Mock()) == result
+
+    def test_post_process_mcp_server_config_accepts_specified_tool_with_none_schema(self):
+        f = post_process_mcp_server_config(["noSchema"], delete_mcp_flag=False)
+        result = {
+            "paths": {
+                "/api/v1/no-schema": {
+                    "get": {
+                        "operationId": "noSchema",
+                        "x-bk-apigateway-resource": {"enableMcp": True, "noneSchema": True},
+                    }
+                }
+            }
+        }
+
+        assert f(result, Mock(), Mock(), Mock()) == result
+
+    def test_post_process_mcp_server_config_raises_for_unknown_specified_tool(self):
+        f = post_process_mcp_server_config(["missingTool"], delete_mcp_flag=False)
+        result = {
+            "paths": {
+                "/api/v1/things": {
+                    "post": {
+                        "operationId": "createThing",
+                        "requestBody": {"content": {}},
+                        "x-bk-apigateway-resource": {"enableMcp": True},
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(Exception, match="not found in resources.yaml"):
+            f(result, Mock(), Mock(), Mock())
+
+    def test_post_process_mcp_server_config_raises_for_invalid_specified_tool(self):
+        f = post_process_mcp_server_config(["noSchema"], delete_mcp_flag=False)
+        result = {
+            "paths": {
+                "/api/v1/no-schema": {
+                    "get": {
+                        "operationId": "noSchema",
+                        "x-bk-apigateway-resource": {"enableMcp": True},
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(Exception, match="noneSchema=True"):
+            f(result, Mock(), Mock(), Mock())
+
+    def test_post_process_mcp_server_config_raises_for_non_mcp_specified_tool(self):
+        f = post_process_mcp_server_config(["plainTool"], delete_mcp_flag=False)
+        result = {
+            "paths": {
+                "/api/v1/plain": {
+                    "get": {
+                        "operationId": "plainTool",
+                        "x-bk-apigateway-resource": {"noneSchema": True},
+                    }
+                }
+            }
+        }
+
+        with pytest.raises(Exception, match="enableMcp=True"):
+            f(result, Mock(), Mock(), Mock())
+class TestCommand:
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.open", new_callable=mock_open)
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.OpenApiYamlRenderer")
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.validate_schema")
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.spectacular_settings")
+    def test_handle(
+        self, mocked_spectacular_settings, mocked_validate_schema, mocked_renderer_cls, mocked_open, settings, tmp_path
+    ):
+        settings.BASE_DIR = str(tmp_path)
+        settings.BK_APIGW_STAGE_ENABLE_MCP_SERVERS = True
+        settings.BK_APIGW_STAGE_BACKEND_SUBPATH = "/backend"
+        mocked_spectacular_settings.POSTPROCESSING_HOOKS = []
+
+        generator = Mock()
+        generator.get_schema.return_value = {"openapi": "3.0.0"}
+        mocked_spectacular_settings.DEFAULT_GENERATOR_CLASS.return_value = generator
+
+        renderer = Mock()
+        renderer.render.return_value = b"rendered"
+        mocked_renderer_cls.return_value = renderer
+
+        command = Command()
+        parser = argparse.ArgumentParser()
+        command.add_arguments(parser)
+
+        assert parser.parse_args(["--tag", "public", "internal"]).tag == ["public", "internal"]
+
+        command.handle(tag=["public"])
+
+        mocked_validate_schema.assert_called_once_with({"openapi": "3.0.0"})
+        renderer.render.assert_called_once_with({"openapi": "3.0.0"}, renderer_context={})
+        mocked_open.assert_called_once_with(tmp_path / "resources.yaml", "wb")
+        mocked_open().write.assert_called_once_with(b"rendered")
+        assert len(mocked_spectacular_settings.POSTPROCESSING_HOOKS) == 3
+
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.open", new_callable=mock_open)
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.OpenApiYamlRenderer")
+    @patch(
+        "apigw_manager.drf.management.commands.generate_resources_yaml.validate_schema", side_effect=Exception("boom")
+    )
+    @patch("apigw_manager.drf.management.commands.generate_resources_yaml.spectacular_settings")
+    def test_handle_raises_schema_validation_error(
+        self,
+        mocked_spectacular_settings,
+        mocked_validate_schema,
+        mocked_renderer_cls,
+        mocked_open,
+        settings,
+        tmp_path,
+    ):
+        settings.BASE_DIR = str(tmp_path)
+        settings.BK_APIGW_STAGE_ENABLE_MCP_SERVERS = False
+        settings.BK_APIGW_STAGE_BACKEND_SUBPATH = ""
+        mocked_spectacular_settings.POSTPROCESSING_HOOKS = []
+
+        generator = Mock()
+        generator.get_schema.return_value = {"openapi": "3.0.0"}
+        mocked_spectacular_settings.DEFAULT_GENERATOR_CLASS.return_value = generator
+        mocked_renderer_cls.return_value = Mock()
+
+        command = Command()
+
+        with pytest.raises(SchemaValidationError, match="boom"):
+            command.handle()
+
+        mocked_validate_schema.assert_called_once_with({"openapi": "3.0.0"})
+        mocked_open.assert_not_called()
+
+    def test_handle_raises_without_base_dir(self):
+        patched_settings = SimpleNamespace(BK_APIGW_STAGE_BACKEND_SUBPATH="")
+
+        with patch("apigw_manager.drf.management.commands.generate_resources_yaml.settings", new=patched_settings):
+            with pytest.raises(AttributeError, match="BASE_DIR"):
+                Command().handle()
+
+    def test_handle_raises_with_invalid_hooks(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_BACKEND_SUBPATH="",
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=object(),
+            DEFAULT_GENERATOR_CLASS=lambda: Mock(),
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_resources_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_resources_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(AttributeError, match="append"):
+                    Command().handle()
+
+    def test_handle_raises_with_invalid_generator_class(self, tmp_path):
+        patched_settings = SimpleNamespace(
+            BASE_DIR=str(tmp_path),
+            BK_APIGW_STAGE_BACKEND_SUBPATH="",
+        )
+        patched_spectacular_settings = SimpleNamespace(
+            POSTPROCESSING_HOOKS=[],
+            DEFAULT_GENERATOR_CLASS=None,
+        )
+
+        with patch("apigw_manager.drf.management.commands.generate_resources_yaml.settings", new=patched_settings):
+            with patch(
+                "apigw_manager.drf.management.commands.generate_resources_yaml.spectacular_settings",
+                new=patched_spectacular_settings,
+            ):
+                with pytest.raises(TypeError, match="NoneType.*callable"):
+                    Command().handle()

--- a/sdks/apigw-manager/tests/apigw_manager/drf/test_apps.py
+++ b/sdks/apigw-manager/tests/apigw_manager/drf/test_apps.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making 蓝鲸智云-蓝鲸 PaaS 平台(BlueKing-PaaS) available.
+# Copyright (C) 2017-2021 THL A29 Limited, a Tencent company. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://opensource.org/licenses/MIT
+# Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+# an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations under the License.
+
+import importlib
+import sys
+
+from apigw_manager.drf.apps import DrfConfig
+
+
+def test_ready_imports_scheme(monkeypatch):
+    drf_module = importlib.import_module("apigw_manager.drf")
+    monkeypatch.delitem(sys.modules, "apigw_manager.drf.scheme", raising=False)
+    monkeypatch.delattr(drf_module, "scheme", raising=False)
+    assert not hasattr(drf_module, "scheme")
+
+    config = DrfConfig("apigw_manager.drf", drf_module)
+    config.ready()
+
+    assert hasattr(drf_module, "scheme")
+    assert "apigw_manager.drf.scheme" in sys.modules

--- a/sdks/apigw-manager/tests/apigw_manager/drf/test_utils.py
+++ b/sdks/apigw-manager/tests/apigw_manager/drf/test_utils.py
@@ -117,7 +117,7 @@ class TestGetLoggingConfigDict:
         )
 
         assert data["formatters"]["verbose"]["()"] == "pythonjsonlogger.jsonlogger.JsonFormatter"
-        assert data["handlers"]["root"]["filename"] == "/tmp/apigw-manager-logs/beat-ab12-django.log"
+        assert data["handlers"]["root"]["filename"] == os.path.join("/tmp/apigw-manager-logs", "beat-ab12-django.log")
         mocked_exists.assert_called_once_with("/tmp/apigw-manager-logs")
         mocked_makedirs.assert_called_once_with("/tmp/apigw-manager-logs")
         mocked_sample.assert_called_once()

--- a/sdks/apigw-manager/tests/apigw_manager/drf/test_utils.py
+++ b/sdks/apigw-manager/tests/apigw_manager/drf/test_utils.py
@@ -10,6 +10,8 @@
 import os
 from unittest import mock
 
+import pytest
+
 from apigw_manager.drf.utils import (
     gen_apigateway_resource_config,
     get_default_database_config_dict,
@@ -50,6 +52,41 @@ class TestGenApigatewayResourceConfig:
             }
         }
 
+    def test_gen_with_mcp_and_disabled_app_verification(self, settings):
+        settings.BK_APIGW_STAGE_ENABLE_MCP_SERVERS = True
+
+        data = gen_apigateway_resource_config(
+            app_verified_required=False,
+            resource_permission_required=True,
+            plugin_configs=[{"name": "test-plugin"}],
+            none_schema=True,
+            enable_mcp=True,
+        )
+
+        assert data == {
+            "x-bk-apigateway-resource": {
+                "isPublic": True,
+                "matchSubpath": False,
+                "backend": {
+                    "name": "default",
+                    "method": "",
+                    "path": "",
+                    "matchSubpath": False,
+                    "timeout": 0,
+                },
+                "pluginConfigs": [{"name": "test-plugin"}],
+                "allowApplyPermission": True,
+                "authConfig": {
+                    "userVerifiedRequired": False,
+                    "appVerifiedRequired": False,
+                    "resourcePermissionRequired": False,
+                },
+                "descriptionEn": "",
+                "noneSchema": True,
+                "enableMcp": True,
+            }
+        }
+
 
 class TestGetLoggingConfigDict:
     def test_get(self):
@@ -67,6 +104,24 @@ class TestGetLoggingConfigDict:
         )
         assert data["formatters"]["verbose"]["format"] == expected_format
 
+    @mock.patch.dict(os.environ, {"BKPAAS_PROCESS_TYPE": "beat"}, clear=False)
+    @mock.patch("apigw_manager.drf.utils.random.sample", return_value=list("ab12"))
+    @mock.patch("apigw_manager.drf.utils.os.path.exists", return_value=False)
+    @mock.patch("apigw_manager.drf.utils.os.makedirs")
+    def test_get_non_local(self, mocked_makedirs, mocked_exists, mocked_sample):
+        data = get_logging_config_dict(
+            log_level="INFO",
+            is_local=False,
+            log_dir="/tmp/apigw-manager-logs",
+            app_code="test",
+        )
+
+        assert data["formatters"]["verbose"]["()"] == "pythonjsonlogger.jsonlogger.JsonFormatter"
+        assert data["handlers"]["root"]["filename"] == "/tmp/apigw-manager-logs/beat-ab12-django.log"
+        mocked_exists.assert_called_once_with("/tmp/apigw-manager-logs")
+        mocked_makedirs.assert_called_once_with("/tmp/apigw-manager-logs")
+        mocked_sample.assert_called_once()
+
 
 class TestGetDefaultDatabaseConfigDict:
     @mock.patch.dict(
@@ -82,6 +137,49 @@ class TestGetDefaultDatabaseConfigDict:
     def test_get(self):
         settings_module = {"DB_PREFIX": "GCS_MYSQL"}
         data = get_default_database_config_dict(settings_module)
+        assert data == {
+            "ENGINE": "django.db.backends.mysql",
+            "NAME": "a",
+            "USER": "b",
+            "PASSWORD": "c",
+            "HOST": "d",
+            "PORT": "e",
+            "OPTIONS": {"isolation_level": "repeatable read"},
+        }
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "GCS_MYSQL_NAME": "a",
+            "MYSQL_NAME": "b",
+        },
+        clear=True,
+    )
+    def test_get_with_multiple_databases_requires_prefix(self):
+        with pytest.raises(EnvironmentError, match="no DB_PREFIX config"):
+            get_default_database_config_dict({})
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_get_without_supported_environment_variables(self, capsys):
+        data = get_default_database_config_dict({})
+
+        assert data == {}
+        assert "DB_PREFIX config is not 'GCS_MYSQL' or 'MYSQL_NAME'" in capsys.readouterr().err
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            "MYSQL_NAME": "a",
+            "MYSQL_USER": "b",
+            "MYSQL_PASSWORD": "c",
+            "MYSQL_HOST": "d",
+            "MYSQL_PORT": "e",
+        },
+        clear=True,
+    )
+    def test_get_with_mysql_prefix(self):
+        data = get_default_database_config_dict({})
+
         assert data == {
             "ENGINE": "django.db.backends.mysql",
             "NAME": "a",


### PR DESCRIPTION
Why this change was needed:
DRF YAML generation now has MCP-related behavior that needs regression coverage, including tool collection, schema validation errors, and definition rendering.

What changed:
- Added tests for generate_definition_yaml rendering, copying, and MCP tool filling
- Expanded generate_resources_yaml coverage for MCP tool validation and command handling
- Covered DRF app ready initialization and utility configuration branches
- Added explicit CommandError guards for invalid MCP definition generation settings

Problem solved:
The DRF gateway YAML helpers are now covered by focused unit tests, making MCP configuration regressions easier to catch before release.