### PR TITLE
feat(apigw-manager): improve MCP Server sync docs and template fields

### DIFF
--- a/sdks/apigw-manager/CHANGE.md
+++ b/sdks/apigw-manager/CHANGE.md
@@ -1,5 +1,12 @@
 ## Change logs
 
+### 4.2.4
+
+- 完善 MCP Server 同步配置文档，新增「1.4 MCP Server 配置说明」章节，包含完整字段说明、分类枚举、配置样例
+- definition.yaml 模板新增 `tool_names`、`oauth2_public_client_enabled`、`category_names` 字段支持
+- 更新 sync-apigateway-with-docker.md 和 sync-apigateway-with-django.md 中的 MCP Server 注释说明
+- README.md 新增 MCP Server 同步功能入口链接
+
 ### 4.2.3
 
 - 支持同步网关环境 MCP Server 配置，新增 Django Command `sync_apigw_stage_mcp_servers`

--- a/sdks/apigw-manager/README.md
+++ b/sdks/apigw-manager/README.md
@@ -28,6 +28,8 @@ pip install "apigw-manager[cryptography]"
    - [直接使用 Django Command 同步](./docs/sync-apigateway-with-django.md): 此方案适用于 Django 项目
    - [通过镜像方式同步](./docs/sync-apigateway-with-docker.md): 此方案适用于非 Django 项目
 
+- [同步 MCP Server](./docs/sync_apigateway.md#14-mcp-server-配置说明)：支持将 MCP Server 配置同步到网关环境，可在 definition.yaml 的 stages 中声明 mcp_servers 配置，使用 `sync_apigw_stage_mcp_servers` 命令进行同步。
+
 - [解析**JWT**](./docs/jwt-explain.md): 使用 Django 中间件，您可以解析蓝鲸 API 网关的 X-Bkapi-JWT 请求头，确保只有来自 API 网关的请求才能访问您的后端服务，提升系统安全性。
 
 

--- a/sdks/apigw-manager/docs/sync-apigateway-with-django.md
+++ b/sdks/apigw-manager/docs/sync-apigateway-with-django.md
@@ -46,7 +46,9 @@ python manage.py sync_resource_docs_by_archive --gateway-name=${gateway_name} --
 # 指定参数 --no-pub 则只生成版本，不发布
 python manage.py create_version_and_release_apigw --gateway-name=${gateway_name} --file="${definition_file}"
 
-# 可选：需要同步 MCP Server 时调用。注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 可选：需要同步 MCP Server 时调用。
+# 注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 需在 definition.yaml 的 stages 中配置 mcp_servers 字段，详见 sync_apigateway.md「1.4 MCP Server 配置说明」
 python manage.py sync_apigw_stage_mcp_servers --gateway-name=${gateway_name} --file="${definition_file}"
 
 # 可选，为应用主动授权
@@ -166,7 +168,12 @@ python manage.py apply_apigw_permissions --gateway-name=${gateway_name} --file="
 # 指定参数 --no-pub 则只生成版本，不发布
 python manage.py create_version_and_release_apigw --gateway-name=${gateway_name} --file="${definition_file}"
 
-# 可选：需要同步 MCP Server 时调用。注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 可选：需要同步 MCP Server 时调用。
+# 注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 需在 definition.yaml 的 stages 中配置 mcp_servers 字段
+# 支持字段: name(必选), title, description(必选), labels, resource_names(必选),
+#   tool_names, is_public, status, protocol_type, target_app_codes, oauth2_public_client_enabled, category_names
+# 详见 sync_apigateway.md「1.4 MCP Server 配置说明」
 python manage.py sync_apigw_stage_mcp_servers --gateway-name=${gateway_name} --file="${definition_file}"
 
 # 获取网关公钥

--- a/sdks/apigw-manager/docs/sync-apigateway-with-django.md
+++ b/sdks/apigw-manager/docs/sync-apigateway-with-django.md
@@ -172,7 +172,8 @@ python manage.py create_version_and_release_apigw --gateway-name=${gateway_name}
 # 注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
 # 需在 definition.yaml 的 stages 中配置 mcp_servers 字段
 # 支持字段: name(必选), title, description(必选), labels, resource_names(必选),
-#   tool_names, is_public, status, protocol_type, target_app_codes, oauth2_public_client_enabled, category_names
+#   tool_names, is_public, status(必选), protocol_type, target_app_codes, oauth2_public_client_enabled,
+#   raw_response_enabled, category_names
 # 详见 sync_apigateway.md「1.4 MCP Server 配置说明」
 python manage.py sync_apigw_stage_mcp_servers --gateway-name=${gateway_name} --file="${definition_file}"
 

--- a/sdks/apigw-manager/docs/sync-apigateway-with-docker.md
+++ b/sdks/apigw-manager/docs/sync-apigateway-with-docker.md
@@ -88,7 +88,9 @@ title "releasing"
 # 指定参数 --no-pub 则只生成版本，不发布
 call_definition_command_or_exit create_version_and_release_apigw "${definition_file}" --gateway-name=${gateway_name}
 
-# 可选：需要同步 MCP Server 时调用。注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 可选：需要同步 MCP Server 时调用。
+# 注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 支持的配置字段详见 sync_apigateway.md「1.4 MCP Server 配置说明」
 # call_definition_command_or_exit sync_apigw_stage_mcp_servers "${definition_file}" --gateway-name=${gateway_name}
 
 log_info "done"
@@ -319,6 +321,10 @@ call_definition_command_or_exit sync_apigw_stage "${definition_file}" --gateway-
 # 可选，同步资源文档
 call_definition_command_or_exit sync_resource_docs_by_archive "${definition_file}" --gateway-name=${gateway_name} --safe-mode
 
-# 可选：需要同步 MCP Server 时调用。注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 可选：需要同步 MCP Server 时调用。
+# 注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
+# 支持的 mcp_servers 字段: name(必选), title, description(必选), labels, resource_names(必选),
+# tool_names, is_public, status, protocol_type, target_app_codes, oauth2_public_client_enabled, category_names
+# 详见 sync_apigateway.md「1.4 MCP Server 配置说明」
 # call_definition_command_or_exit sync_apigw_stage_mcp_servers "${definition_file}" --gateway-name=${gateway_name}
 ```

--- a/sdks/apigw-manager/docs/sync-apigateway-with-docker.md
+++ b/sdks/apigw-manager/docs/sync-apigateway-with-docker.md
@@ -324,7 +324,8 @@ call_definition_command_or_exit sync_resource_docs_by_archive "${definition_file
 # 可选：需要同步 MCP Server 时调用。
 # 注意：前提是该 stage 有生效的版本且声明的 mcp tool 在生效版本的资源列表里且确认过请求参数
 # 支持的 mcp_servers 字段: name(必选), title, description(必选), labels, resource_names(必选),
-# tool_names, is_public, status, protocol_type, target_app_codes, oauth2_public_client_enabled, category_names
+# tool_names, is_public, status(必选), protocol_type, target_app_codes, oauth2_public_client_enabled,
+# raw_response_enabled, category_names
 # 详见 sync_apigateway.md「1.4 MCP Server 配置说明」
 # call_definition_command_or_exit sync_apigw_stage_mcp_servers "${definition_file}" --gateway-name=${gateway_name}
 ```

--- a/sdks/apigw-manager/docs/sync_apigateway.md
+++ b/sdks/apigw-manager/docs/sync_apigateway.md
@@ -117,13 +117,15 @@ stages:
 #        is_public: true
 #        # MCP 协议类型：sse（默认）、streamable_http
 #        protocol_type: "sse"
-#        # 1: 开启, 0: 停止；默认关闭
+#        # 1: 开启, 0: 停止（必选字段）
 #        status: 1
 #        # 授权的应用
 #        target_app_codes:
 #          - "bk_app_code1"
 #        # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用授权，默认不开启
 #        oauth2_public_client_enabled: false
+#        # 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启
+#        raw_response_enabled: false
 #        # MCP Server 分类名称列表，不传则不更新分类
 #        category_names:
 #          - "Official"
@@ -208,13 +210,15 @@ stages:
     #     is_public: true
     #     # MCP 协议类型：sse（默认）、streamable_http
     #     protocol_type: "sse"
-    #     # 1: 开启, 0: 停止；默认关闭
+    #     # 1: 开启, 0: 停止（必选字段）
     #     status: 1
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
     #     # 是否开启 OAuth2 公开客户端模式
     #     oauth2_public_client_enabled: false
+    #     # 是否返回原始响应，开启后 mcp-proxy 直接返回 API 响应结果
+    #     raw_response_enabled: false
     #     # MCP Server 分类名称列表
     #     category_names:
     #       - "Official"
@@ -412,10 +416,11 @@ resource_docs:
 | `resource_names` | array[string] | 是 | MCP Server 关联的资源列表，对应 resources.yaml 中定义的资源名称 |
 | `tool_names` | array[string] | 否 | MCP Server 工具名称列表，默认等于 resource_names。如需对资源进行重命名可设置此字段，长度必须与 resource_names 一致，且不能重复 |
 | `is_public` | bool | 否 | 是否公开，默认不公开 |
-| `status` | integer | 否 | 状态：1 表示启用，0 表示关闭（默认关闭） |
+| `status` | integer | 是 | 状态：1 表示启用，0 表示关闭 |
 | `protocol_type` | string | 否 | MCP 协议类型：`sse`（默认）、`streamable_http` |
 | `target_app_codes` | array[string] | 否 | 主动授权的应用列表 |
 | `oauth2_public_client_enabled` | bool | 否 | 是否开启 OAuth2 公开客户端模式，开启后将对 `bk_app_code=public` 的应用进行授权，默认不开启 |
+| `raw_response_enabled` | bool | 否 | 是否返回原始响应，开启后 mcp-proxy 将直接返回 API 响应结果，不添加 request_id 等额外信息，默认不开启 |
 | `category_names` | array[string] | 否 | MCP Server 分类名称列表，不传则不更新分类 |
 
 #### 支持的分类（category_names）
@@ -475,6 +480,7 @@ stages:
           - "bk_nodeman"
           - "bk_sops"
         oauth2_public_client_enabled: false
+        raw_response_enabled: false
         category_names:
           - "Automation"
           - "Official"

--- a/sdks/apigw-manager/docs/sync_apigateway.md
+++ b/sdks/apigw-manager/docs/sync_apigateway.md
@@ -100,22 +100,33 @@ stages:
           hosts:
             - host: "http://httpbin.org"
               weight: 100
-#  同步 MCP Server 相关配置
+#  同步 MCP Server 相关配置（详细字段说明见下方「1.4 MCP Server 配置说明」）
 #    mcp_servers:
-#      - name: "mcp_server1",
+#      - name: "mcp_server1"
+#        title: "MCP服务1"
 #        description: "mcp-server demo"
-#        labels: 
+#        labels:
 #          - "test"
-#        # 添加的tool对应的资源名称
+#        # 添加的 tool 对应的资源名称
 #        resource_names:
 #          - resource1
-#        # 是否公开
+#        # 工具名称列表，默认等于 resource_names；如需重命名可设置此字段，长度必须与 resource_names 一致且不能重复
+#        tool_names:
+#          - tool1
+#        # 是否公开，默认不公开
 #        is_public: true
-#        # 1: 开启,0: 停止; 默认是开启
+#        # MCP 协议类型：sse（默认）、streamable_http
+#        protocol_type: "sse"
+#        # 1: 开启, 0: 停止；默认关闭
 #        status: 1
 #        # 授权的应用
 #        target_app_codes:
 #          - "bk_app_code1"
+#        # 是否开启 OAuth2 公开客户端模式，开启后将对 bk_app_code=public 的应用授权，默认不开启
+#        oauth2_public_client_enabled: false
+#        # MCP Server 分类名称列表，不传则不更新分类
+#        category_names:
+#          - "Official"
 ```
 
 > 📢 注意：如果之前接入过的，建议将 spec_version 改成 2，并将原先 `stage:{}`改成 `stages: []`
@@ -180,22 +191,33 @@ stages:
         hosts:
           - host: ""
             weight: 100
-    #  同步 MCP Server 相关配置
+    #  同步 MCP Server 相关配置（详细字段说明见下方「1.4 MCP Server 配置说明」）
     # mcp_servers:
-    #  - name: "mcp_server1"
-    #    description: "mcp-server demo"
-    #    labels: 
-    #      - "test"
-    #    # 添加的tool对应的资源名称
-    #    resource_names:
-    #      - resource1
-    #    # 是否公开
-    #    is_public: true
-    #    # 1: 开启,0: 停止；默认是开启
-    #    status: 1
-    #    # 授权的应用
+    #   - name: "mcp_server1"
+    #     title: "MCP服务1"
+    #     description: "mcp-server demo"
+    #     labels:
+    #       - "test"
+    #     # 添加的 tool 对应的资源名称
+    #     resource_names:
+    #       - resource1
+    #     # 工具名称列表，默认等于 resource_names；如需重命名可设置此字段
+    #     tool_names:
+    #       - tool1
+    #     # 是否公开，默认不公开
+    #     is_public: true
+    #     # MCP 协议类型：sse（默认）、streamable_http
+    #     protocol_type: "sse"
+    #     # 1: 开启, 0: 停止；默认关闭
+    #     status: 1
+    #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否开启 OAuth2 公开客户端模式
+    #     oauth2_public_client_enabled: false
+    #     # MCP Server 分类名称列表
+    #     category_names:
+    #       - "Official"
 
     # 环境插件配置
     # plugin_configs:
@@ -369,9 +391,114 @@ resource_docs:
   basedir: "support-files/apidocs/"
 ```
 
-### 1.4 国际化支持
+### 1.4 MCP Server 配置说明
 
-#### 1.4.1 网关描述国际化
+在 definition.yaml 的 `stages` 配置中，每个 stage 可以配置 `mcp_servers` 来声明该环境的 MCP Server。同步 MCP Server 使用命令 `sync_apigw_stage_mcp_servers`。
+
+> ⚠️ **前提条件：**
+> - 仅支持 `spec_version: 2`
+> - 该 stage 需要有已生效的资源版本（即已发布过）
+> - 声明的 MCP tool（resource_names 中的资源）必须在生效版本的资源列表中
+> - 相关资源的请求参数（body, path, header, query）需已确认；如果资源没有请求参数，需在 resources.yaml 中显式设置 `noneSchema: true`
+
+#### 字段说明
+
+| 参数名称 | 参数类型 | 必选 | 描述 |
+|---------|---------|------|------|
+| `name` | string | 是 | MCP Server 名字，例如 `"mcp1"`（系统会自动转换为 `{gateway_name}-{stage_name}-{name}`） |
+| `title` | string | 否 | MCP Server 中文名/显示名称 |
+| `description` | string | 是 | MCP Server 描述 |
+| `labels` | array[string] | 否 | MCP Server 标签 |
+| `resource_names` | array[string] | 是 | MCP Server 关联的资源列表，对应 resources.yaml 中定义的资源名称 |
+| `tool_names` | array[string] | 否 | MCP Server 工具名称列表，默认等于 resource_names。如需对资源进行重命名可设置此字段，长度必须与 resource_names 一致，且不能重复 |
+| `is_public` | bool | 否 | 是否公开，默认不公开 |
+| `status` | integer | 否 | 状态：1 表示启用，0 表示关闭（默认关闭） |
+| `protocol_type` | string | 否 | MCP 协议类型：`sse`（默认）、`streamable_http` |
+| `target_app_codes` | array[string] | 否 | 主动授权的应用列表 |
+| `oauth2_public_client_enabled` | bool | 否 | 是否开启 OAuth2 公开客户端模式，开启后将对 `bk_app_code=public` 的应用进行授权，默认不开启 |
+| `category_names` | array[string] | 否 | MCP Server 分类名称列表，不传则不更新分类 |
+
+#### 支持的分类（category_names）
+
+| 分类标识 | 描述 |
+|---------|------|
+| `Uncategorized` | 未分类 |
+| `Official` | 官方资源 |
+| `Featured` | 精选推荐 |
+| `Monitoring` | 监控告警 |
+| `ConfigManagement` | 配置管理 |
+| `DevOps` | 持续交付 |
+| `Emergency` | 故障管理 |
+| `Database` | 数据服务 |
+| `Automation` | 运维自动化 |
+| `Observability` | 可观测性 |
+| `Security` | 安全合规 |
+| `ResourceOptimize` | 资源优化 |
+| `ChaosEngineering` | 混沌工程 |
+| `Network` | 网络管理 |
+
+#### 完整配置样例
+
+```yaml
+spec_version: 2
+
+stages:
+  - name: "prod"
+    description: "生产环境"
+    backends:
+      - name: "default"
+        config:
+          timeout: 60
+          loadbalance: "roundrobin"
+          hosts:
+            - host: "http://api.example.com"
+              weight: 100
+    mcp_servers:
+      - name: "my-mcp-server"
+        title: "我的 MCP 服务"
+        description: "提供 XXX 能力的 MCP Server"
+        labels:
+          - "ops"
+          - "automation"
+        resource_names:
+          - "get_hosts"
+          - "search_hosts"
+          - "execute_job"
+        tool_names:
+          - "get_hosts"
+          - "search_hosts"
+          - "run_job"
+        is_public: true
+        protocol_type: "streamable_http"
+        status: 1
+        target_app_codes:
+          - "bk_nodeman"
+          - "bk_sops"
+        oauth2_public_client_enabled: false
+        category_names:
+          - "Automation"
+          - "Official"
+```
+
+#### 同步命令
+
+- **Django Command 方式：**
+
+```bash
+python manage.py sync_apigw_stage_mcp_servers --gateway-name=${gateway_name} --file="${definition_file}"
+```
+
+- **镜像方式（使用 functions.sh）：**
+
+```bash
+call_definition_command_or_exit sync_apigw_stage_mcp_servers "${definition_file}" --gateway-name=${gateway_name}
+```
+
+> 📢 **注意：** 必须在 `create_version_and_release_apigw`（创建版本并发布）之后再执行 `sync_apigw_stage_mcp_servers`，否则可能因无生效版本导致同步失败。
+
+### 1.5 国际化支持
+
+#### 1.5.1 网关描述国际化
 
 在 definition.yaml 中利用字段 description_en 指定英文描述。样例：
 
@@ -384,7 +511,7 @@ apigateway:
     - "admin"
 ```
 
-#### 1.4.2 环境描述国际化
+#### 1.5.2 环境描述国际化
 
 在 definition.yaml 中利用字段 description_en 指定英文描述。样例：
 
@@ -395,7 +522,7 @@ stage:
   description_en: "This is the English description"
 ```
 
-#### 1.4.3 资源描述国际化
+#### 1.5.3 资源描述国际化
 
 可以在 resources.yaml 对应的 `x-bk-apigateway-resource` 的 `descriptionEn` 指定英文描述
 

--- a/sdks/apigw-manager/examples/chart/use-configmap/files/support-files/definition.yaml
+++ b/sdks/apigw-manager/examples/chart/use-configmap/files/support-files/definition.yaml
@@ -40,13 +40,15 @@ stages:
     #       - resource1
     #     # 是否公开
     #     is_public: true
-    #     # 1: 开启, 0: 停止; 默认是开启
+    #     # 1: 开启, 0: 停止（必选字段）
     #     status: 1
     #     # MCP 协议类型: sse（默认）、streamable_http
     #     protocol_type: "sse"
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否返回原始响应，开启后 mcp-proxy 直接返回 API 响应结果，默认不开启
+    #     raw_response_enabled: false
 
     # 环境插件配置
     # plugin_configs:

--- a/sdks/apigw-manager/examples/chart/use-custom-docker-image/my-apigw-manager/support-files/definition.yaml
+++ b/sdks/apigw-manager/examples/chart/use-custom-docker-image/my-apigw-manager/support-files/definition.yaml
@@ -40,13 +40,15 @@ stages:
     #       - resource1
     #     # 是否公开
     #     is_public: true
-    #     # 1: 开启, 0: 停止; 默认是开启
+    #     # 1: 开启, 0: 停止（必选字段）
     #     status: 1
     #     # MCP 协议类型: sse（默认）、streamable_http
     #     protocol_type: "sse"
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否返回原始响应，开启后 mcp-proxy 直接返回 API 响应结果，默认不开启
+    #     raw_response_enabled: false
 
     # 环境插件配置
     # plugin_configs:

--- a/sdks/apigw-manager/examples/django/use-custom-script/support-files/definition.yaml
+++ b/sdks/apigw-manager/examples/django/use-custom-script/support-files/definition.yaml
@@ -40,13 +40,15 @@ stages:
     #       - resource1
     #     # 是否公开
     #     is_public: true
-    #     # 1: 开启, 0: 停止; 默认是开启
+    #     # 1: 开启, 0: 停止（必选字段）
     #     status: 1
     #     # MCP 协议类型: sse（默认）、streamable_http
     #     protocol_type: "sse"
     #     # 授权的应用
     #     target_app_codes:
     #       - "bk_app_code1"
+    #     # 是否返回原始响应，开启后 mcp-proxy 直接返回 API 响应结果，默认不开启
+    #     raw_response_enabled: false
 
 # 资源文档
 # 资源文档的目录格式样例如下，en 为英文文档，zh 为中文文档：

--- a/sdks/apigw-manager/pyproject.toml
+++ b/sdks/apigw-manager/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apigw-manager"
-version = "4.2.3"
+version = "4.2.4"
 description = "The SDK for managing blueking gateway resource."
 readme = "README.md"
 authors = ["blueking <blueking@tencent.com>"]

--- a/sdks/apigw-manager/src/apigw_manager/drf/management/commands/data/definition.yaml
+++ b/sdks/apigw-manager/src/apigw_manager/drf/management/commands/data/definition.yaml
@@ -94,6 +94,9 @@ stages:
         {% if mcp_server.oauth2_public_client_enabled %}
         oauth2_public_client_enabled: {{ mcp_server.oauth2_public_client_enabled }}
         {% endif %}
+        {% if mcp_server.raw_response_enabled %}
+        raw_response_enabled: {{ mcp_server.raw_response_enabled }}
+        {% endif %}
         {% if mcp_server.category_names %}
         category_names:
           {% for category in mcp_server.category_names %}

--- a/sdks/apigw-manager/src/apigw_manager/drf/management/commands/data/definition.yaml
+++ b/sdks/apigw-manager/src/apigw_manager/drf/management/commands/data/definition.yaml
@@ -76,6 +76,12 @@ stages:
           {% for resource in mcp_server.tools %}
           - "{{ resource }}"
           {% endfor %}
+        {% if mcp_server.tool_names %}
+        tool_names:
+          {% for tool_name in mcp_server.tool_names %}
+          - "{{ tool_name }}"
+          {% endfor %}
+        {% endif %}
         is_public: {{ mcp_server.is_public }}
         protocol_type: "{{ mcp_server.protocol_type }}"
         status: {{ mcp_server.status }}
@@ -83,6 +89,15 @@ stages:
         target_app_codes:
           {% for app_code in mcp_server.target_app_codes %}
           - "{{ app_code }}"
+          {% endfor %}
+        {% endif %}
+        {% if mcp_server.oauth2_public_client_enabled %}
+        oauth2_public_client_enabled: {{ mcp_server.oauth2_public_client_enabled }}
+        {% endif %}
+        {% if mcp_server.category_names %}
+        category_names:
+          {% for category in mcp_server.category_names %}
+          - "{{ category }}"
           {% endfor %}
         {% endif %}
       {% endfor %}


### PR DESCRIPTION
## Changes

- Add section '1.4 MCP Server Configuration' in `docs/sync_apigateway.md` with full field descriptions, category enums, and configuration examples
- Add `tool_names`, `oauth2_public_client_enabled`, `category_names` fields support to `definition.yaml` Django template
- Update MCP Server sync comments in `sync-apigateway-with-docker.md` and `sync-apigateway-with-django.md`
- Add MCP Server sync feature entry link in `README.md`
- Bump version to 4.2.4

## Background

The `sync_apigw_stage_mcp_servers` command was introduced in v4.2.3, but the documentation lacked detailed field descriptions. This PR enriches the docs based on the latest `v2_sync_stage_mcp_servers` API schema from bk-apigateway, including:

- Complete field reference table (12 fields)
- Supported category names enumeration (14 categories)
- Full YAML configuration example
- Prerequisites and usage notes