### PR TITLE
feat(apigw-manager): add Python 3.14 support

### DIFF
--- a/sdks/apigw-manager/CHANGE.md
+++ b/sdks/apigw-manager/CHANGE.md
@@ -2,7 +2,7 @@
 
 ### 5.0.0
 
-- [breaking change] drop support for python 3.8/3.9/3.10, request >=3.11 and < 3.14
+- [breaking change] drop support for python 3.8/3.9/3.10, request >=3.11 and < 3.15
 - [breaking change] drop support for Django 3.x / 4.x, request Django >=5.2,<6.0 (LTS)
 - [breaking change] 升级所有 bk-apigateway API 从 v1 到 v2 版本
   - 所有 API 调用改为使用 v2 版本（如 `v2_sync_gateway`、`v2_sync_stages` 等）

--- a/sdks/apigw-manager/pyproject.toml
+++ b/sdks/apigw-manager/pyproject.toml
@@ -11,7 +11,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<3.14"
+python = ">=3.11,<3.15"
 setuptools = ">=78.1.1"
 urllib3 = ">=1.25.3"
 pyyaml = ">=5.4.2"
@@ -22,6 +22,7 @@ django-environ = { version = ">=0.8.1", optional = true }
 Django = { version = ">=5.2.0,<6.0.0", optional = true }
 cryptography = { version = ">=3.1.1", optional = true }
 packaging = { version = ">=20.4" }
+jsonschema = ">=4.23.0"
 PyMySQL = { version = "^1.0.2", optional = true }
 kubernetes = { version = "*", optional = true }
 djangorestframework = { version = ">=3.10.3", optional = true }
@@ -76,7 +77,7 @@ license = "MIT"
 dynamic = ["version", "classifiers", "dependencies"]
 readme = "README.md"
 authors = [{name = "blueking", email = "blueking@tencent.com"}]
-requires-python = '>=3.11,<3.14'
+requires-python = '>=3.11,<3.15'
 
 
 [project.urls]

--- a/sdks/apigw-manager/tox.ini
+++ b/sdks/apigw-manager/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.23.0
 isolated_build = True
-envlist = py{311,312,313}-django{52}-pyjwt{2}
+envlist = py{311,312,313,314}-django{52}-pyjwt{2}
 
 
 [gh-actions]
@@ -9,12 +9,16 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [testenv]
-extras = cryptography
-allowlist_externals = pytest
+extras = cryptography,drf,demo,kubernetes
 deps =
+    pytest>=8.3.3
+    pytest-django>=4.9.0
+    pytest-mock>=3.14.0
+    Faker==33.0.0
     django52: django>=5.2,<6.0
     pyjwt2: pyjwt<3
 commands =
-    pytest -v --ds demo.settings tests
+    python -m pytest -v --ds demo.settings tests


### PR DESCRIPTION
## Summary
- widen apigw-manager support metadata from Python 3.13 to Python 3.14
- update tox to run a self-contained full-suite matrix for py311 through py314
- add the missing runtime and test dependency wiring needed to validate the full suite

## Validation
- PYENV_VERSION='3.11.15:3.12.13:3.13.13:3.14.5:apigw-manager' tox -r