### PR TITLE
fix(apigw-manager): make sdk generation opt-in

### DIFF
--- a/sdks/apigw-manager/bin/sync-apigateway.sh
+++ b/sdks/apigw-manager/bin/sync-apigateway.sh
@@ -22,7 +22,7 @@ title "fetch esb public key"
 call_command_or_warning fetch_esb_public_key ${FETCH_ESB_PUBLIC_KEY_ARGS}
 
 title "releasing"
-call_definition_command_or_exit create_version_and_release_apigw "${definition_file}" ${CREATE_VERSION_AND_RELEASE_APIGW_ARGS:-"--generate-sdks"}
+call_definition_command_or_exit create_version_and_release_apigw "${definition_file}" ${CREATE_VERSION_AND_RELEASE_APIGW_ARGS}
 
 
 if [[ "${ENABLE_SYNC_MCP_SERVERS}" = "true" ]]; then

--- a/sdks/apigw-manager/docs/sync-apigateway-with-docker.md
+++ b/sdks/apigw-manager/docs/sync-apigateway-with-docker.md
@@ -31,7 +31,7 @@
 - `GRANT_APIGW_PERMISSIONS_ARGS`: 用于命令 `grant_apigw_permissions`，授权网关权限
 - `SYNC_APIGW_RESOURCES_ARGS`: 默认值："--delete"，用于命令 `sync_apigw_resources`，同步网关资源
 - `SYNC_RESOURCE_DOCS_BY_ARCHIVE_ARGS`: 默认值： "--safe-mode"，用于命令 `sync_resource_docs_by_archive`，同步网关文档
-- `CREATE_VERSION_AND_RELEASE_APIGW_ARGS`: 默认值："--generate-sdks"，用于命令 `create_version_and_release_apigw`,创建资源版本并发布
+- `CREATE_VERSION_AND_RELEASE_APIGW_ARGS`: 默认值为空，用于命令 `create_version_and_release_apigw`，创建资源版本并发布；如需同时生成资源版本对应的网关 SDK，请显式设置为 `"--generate-sdks"`
 - `ENABLE_SYNC_MCP_SERVERS`: 用于命令 `sync_apigw_stage_mcp_servers`, 是否开启同步环境 MCP Server
 - `SYNC_APIGW_STAGE_MCP_SERVERS_ARGS`: 用于命令 `sync_apigw_stage_mcp_servers`，同步环境 MCP Server 的额外参数
 


### PR DESCRIPTION
## Summary
- Remove the default `--generate-sdks` fallback from the apigw-manager base image sync script.
- Document that `CREATE_VERSION_AND_RELEASE_APIGW_ARGS` defaults to empty and SDK generation must be enabled explicitly with `--generate-sdks`.

## Verification
- `bash -n bin/sync-apigateway.sh`
- `git diff --check`
- `if rg -n -e 'CREATE_VERSION_AND_RELEASE_APIGW_ARGS:-' -e 'CREATE_VERSION_AND_RELEASE_APIGW_ARGS.*generate-sdks' bin/sync-apigateway.sh; then exit 1; fi`