### PR TITLE
fix(apigw-manager): parse v2 api responses

### DIFF
--- a/sdks/apigw-manager/CHANGE.md
+++ b/sdks/apigw-manager/CHANGE.md
@@ -1,5 +1,12 @@
 ## Change logs
 
+### 5.0.1
+
+- [fix] 修复 v2 API 响应解析逻辑，20x 响应直接返回 `data`，非 20x 响应从 `error` 中解析错误信息
+- [fix] 适配 v2 资源版本接口返回结构，资源版本列表使用数组判断是否存在，发布时不再依赖资源版本响应中的 `comment`
+- [fix] 修复同步环境 MCP Server 时重复读取 `data` 导致同步结果无法输出的问题
+- [fix] `apply_apigw_permissions` 申请权限时补充 v2 接口必填的 `applicant` 字段
+
 ### 5.0.0
 
 - [feat] generate_resources_yaml 命令支持合并手动配置的额外资源文件

--- a/sdks/apigw-manager/pyproject.toml
+++ b/sdks/apigw-manager/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apigw-manager"
-version = "5.0.0"
+version = "5.0.1"
 description = "The SDK for managing blueking gateway resource."
 readme = "README.md"
 authors = ["blueking <blueking@tencent.com>"]

--- a/sdks/apigw-manager/src/apigw_manager/apigw/management/commands/apply_apigw_permissions.py
+++ b/sdks/apigw-manager/src/apigw_manager/apigw/management/commands/apply_apigw_permissions.py
@@ -30,6 +30,7 @@ class Command(PermissionCommand):
 
         for permission in definition:
             permission.setdefault("target_app_code", manager.config.bk_app_code)
+            permission.setdefault("applicant", permission["target_app_code"])
 
             # v2 使用 gateway_name 替代 api_name
             if "api_name" in permission:

--- a/sdks/apigw-manager/src/apigw_manager/apigw/management/commands/create_version_and_release_apigw.py
+++ b/sdks/apigw-manager/src/apigw_manager/apigw/management/commands/create_version_and_release_apigw.py
@@ -88,7 +88,7 @@ class Command(DefinitionCommand):
 
     def _check_resource_version_exists(self, fetcher, version):
         resource_versions = fetcher.list_resource_versions(version=str(version))
-        return resource_versions["count"] != 0
+        return bool(resource_versions)
 
     def _generate_sdks(self, releaser, version, *args, **kwargs):
         try:
@@ -132,7 +132,7 @@ class Command(DefinitionCommand):
         if not no_pub:
             result = releaser.release(
                 version=resource_version["version"],
-                comment=comment or resource_version.get("comment", ""),
+                comment=comment or "",
                 stage_names=stage,
             )
             print(

--- a/sdks/apigw-manager/src/apigw_manager/apigw/management/commands/sync_apigw_stage_mcp_servers.py
+++ b/sdks/apigw-manager/src/apigw_manager/apigw/management/commands/sync_apigw_stage_mcp_servers.py
@@ -34,7 +34,7 @@ class Command(SyncCommand):
     def do(self, manager, definition, *args, **kwargs):
         for stage_definition in definition:
             result = manager.sync_stage_mcp_servers(**stage_definition)
-            for mcp_sync_result in result.get("data", []):
+            for mcp_sync_result in result:
                 print(
                     "API gateway stage mcp servers synchronization completed [ id:%s,name:%s,action:%s ]"
                     % (mcp_sync_result["id"], mcp_sync_result["name"], mcp_sync_result["action"])

--- a/sdks/apigw-manager/src/apigw_manager/core/fetch.py
+++ b/sdks/apigw-manager/src/apigw_manager/core/fetch.py
@@ -16,7 +16,6 @@
 # to the current version of the project delivered to anyone in the future.
 
 from apigw_manager.core.handler import Handler
-from apigw_manager.core.utils import itemgetter
 
 
 class Fetcher(Handler):
@@ -25,13 +24,13 @@ class Fetcher(Handler):
     def public_key(self, *args, **kwargs):
         """Get the API gateway public key according to the name"""
         result = self._call_v2_with_cache(self.client.api.v2_sync_get_gateway_public_key_new, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def latest_resource_version(self, *args, **kwargs):
         """Get the latest resource version"""
         result = self._call_v2(self.client.api.v2_sync_get_latest_resource_version, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def list_resource_versions(self, *args, **kwargs):
         result = self._call_v2(self.client.api.v2_sync_list_resource_versions, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)

--- a/sdks/apigw-manager/src/apigw_manager/core/handler.py
+++ b/sdks/apigw-manager/src/apigw_manager/core/handler.py
@@ -65,24 +65,6 @@ class Handler(object):
 
         return False
 
-    def _call_with_cache(self, operation, **kwargs):
-        """Call the API instance, allow data to be retrieved from the cache"""
-        cache_key = {
-            "gateway_name": kwargs.get("gateway_name", self.config.gateway_name),
-            "kwargs": kwargs,
-        }
-
-        operation_id = operation.name
-        cached, result = self._get_from_cache(operation_id, cache_key)
-        if cached:
-            return result
-
-        result = self._call(operation, **kwargs)
-
-        self._put_into_cache(operation_id, cache_key, result)
-
-        return result
-
     def _call_v2_with_cache(self, operation, **kwargs):
         """Call the API instance (v2), allow data to be retrieved from the cache"""
         cache_key = {
@@ -123,31 +105,6 @@ class Handler(object):
         )
         return bk_app_tenant_id
 
-    def _call(self, operation, files=None, **kwargs):
-        """Call the API instance"""
-        data = {
-            "path_params": {"api_name": kwargs.pop("gateway_name", self.config.gateway_name)},
-            "data": kwargs,
-            "headers": {
-                "X-Bkapi-Authorization": kwargs.pop("x_bkapi_authorization", self._get_bkapi_authorization()),
-                # the header is required by the API gateway plugin bk-tenant-validate, for global tenant app!
-                # so we set it to system, it would not be used in the gateway
-                "X-Bk-Tenant-Id": self._get_tenant_id(),
-            },
-            "files": files,
-        }
-
-        operation_id = operation.name
-        logger.debug("call api %s, data: %s", operation_id, data)
-
-        try:
-            return operation(**data)
-        except ResponseError as err:
-            message = "%s\n%s\nResponse: %s" % (err, err.curl_command, err.response_text)
-            raise ApiResponseError(message)
-        except Exception as err:
-            raise ApiException(operation_id) from err
-
     def _call_v2(self, operation, files=None, **kwargs):
         """Call the API instance (v2 version):
           - Uses "gateway_name" as the key in `path_params` instead of "api_name".
@@ -180,18 +137,33 @@ class Handler(object):
         try:
             return operation(**data)
         except ResponseError as err:
+            if err.response_status_code is not None and not self._is_success_status_code(err.response_status_code):
+                self._raise_v2_result_error(self._get_response_json(err), err.response_status_code, err.response_text)
+
             message = "%s\n%s\nResponse: %s" % (err, err.curl_command, err.response_text)
             raise ApiResponseError(message)
         except Exception as err:
             raise ApiException(operation_id) from err
 
-    def _parse_result(self, result, convertor, code=0):
-        """Check the code and convert the result"""
-        logger.debug("code %s, message: %s", result.get("code"), result.get("message"))
-        if result.get("code") != code:
+    def _parse_v2_result(self, result):
+        """Convert the v2 API response body."""
+        return result.get("data")
+
+    def _raise_v2_result_error(self, result, status_code, response_text):
+        if isinstance(result, dict) and result.get("error"):
+            error = result["error"]
             raise ApiResultError(
-                result.get("code"),
-                result.get("message"),
+                error.get("code"),
+                error.get("message"),
             )
 
-        return convertor(result)
+        raise ApiResultError(status_code, response_text)
+
+    def _get_response_json(self, err):
+        try:
+            return err.response_json()
+        except (TypeError, ValueError):
+            return None
+
+    def _is_success_status_code(self, status_code):
+        return status_code is not None and 200 <= status_code < 300

--- a/sdks/apigw-manager/src/apigw_manager/core/permission.py
+++ b/sdks/apigw-manager/src/apigw_manager/core/permission.py
@@ -16,7 +16,6 @@
 # to the current version of the project delivered to anyone in the future.
 
 from apigw_manager.core.handler import Handler
-from apigw_manager.core.utils import itemgetter
 
 
 class Manager(Handler):
@@ -25,9 +24,9 @@ class Manager(Handler):
     def apply_permission(self, *args, **kwargs):
         """Apply for API Gateway Permissions"""
         result = self._call_v2(self.client.api.v2_open_apply_gateway_permission, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def grant_permission(self, *args, **kwargs):
         """Grant API gateway permissions for applications"""
         result = self._call_v2(self.client.api.v2_sync_grant_permission, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)

--- a/sdks/apigw-manager/src/apigw_manager/core/release.py
+++ b/sdks/apigw-manager/src/apigw_manager/core/release.py
@@ -16,7 +16,6 @@
 # to the current version of the project delivered to anyone in the future.
 
 from apigw_manager.core.handler import Handler
-from apigw_manager.core.utils import itemgetter
 
 
 class Releaser(Handler):
@@ -27,17 +26,17 @@ class Releaser(Handler):
         kwargs.pop("title", None)
 
         result = self._call_v2(self.client.api.v2_sync_create_resource_version, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def release(self, *args, **kwargs):
         """release a version"""
         kwargs.pop("title", None)
 
         result = self._call_v2(self.client.api.v2_sync_release, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def generate_sdks(self, *args, **kwargs):
         """generate sdks"""
 
         result = self._call_v2(self.client.api.v2_sync_generate_sdk, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)

--- a/sdks/apigw-manager/src/apigw_manager/core/sync.py
+++ b/sdks/apigw-manager/src/apigw_manager/core/sync.py
@@ -18,7 +18,6 @@
 import yaml
 
 from apigw_manager.core.handler import Handler
-from apigw_manager.core.utils import itemgetter
 
 
 class Synchronizer(Handler):
@@ -26,27 +25,28 @@ class Synchronizer(Handler):
 
     def sync_basic_config(self, *args, **kwargs):
         result = self._call_v2(self.client.api.v2_sync_gateway, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def sync_stage_config(self, *args, **kwargs):
         result = self._call_v2(self.client.api.v2_sync_stages, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def sync_stage_mcp_servers(self, *args, **kwargs):
-        return self._call_v2(self.client.api.v2_sync_stage_mcp_servers, *args, **kwargs)
+        result = self._call_v2(self.client.api.v2_sync_stage_mcp_servers, *args, **kwargs)
+        return self._parse_v2_result(result)
 
     def sync_resources_config(self, content, *args, **kwargs):
         kwargs["content"] = yaml.dump(dict(content))
 
         result = self._call_v2(self.client.api.v2_sync_resources, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def sync_resource_docs_by_archive(self, *args, **kwargs):
         result = self._call_v2(self.client.api.v2_sync_resource_doc, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)
 
     def add_related_apps(self, *args, **kwargs):
         kwargs["related_app_codes"] = kwargs.pop("related_apps")
 
         result = self._call_v2(self.client.api.v2_sync_add_related_apps, *args, **kwargs)
-        return self._parse_result(result, itemgetter("data"))
+        return self._parse_v2_result(result)

--- a/sdks/apigw-manager/src/apigw_manager/core/utils.py
+++ b/sdks/apigw-manager/src/apigw_manager/core/utils.py
@@ -19,15 +19,6 @@ from functools import reduce
 from operator import getitem
 
 
-def itemgetter(*keys):
-    """Chaining value getter of dict"""
-
-    def getter(r):
-        return get_item(r, keys)
-
-    return getter
-
-
 def get_item(r, keys):
     """Get the value according to the keys"""
     return reduce(getitem, keys, r)

--- a/sdks/apigw-manager/tests/apigw_manager/apigw/management/commands/test_apply_apigw_permissions.py
+++ b/sdks/apigw-manager/tests/apigw_manager/apigw/management/commands/test_apply_apigw_permissions.py
@@ -33,24 +33,27 @@ def test_do(mock_manager, command, configuration):
         [
             {"api_name": "test1"},
             {"gateway_name": "test2", "grant_dimension": "resource", "resource_names": ["get_user"]},
-            {"gateway_name": "test3", "grant_dimension": "api"},
+            {"gateway_name": "test3", "grant_dimension": "api", "applicant": "admin"},
         ],
     )
 
     # v2 使用 gateway_name 替代 api_name，默认按 gateway 维度申请
     mock_manager.apply_permission.assert_any_call(
         target_app_code=configuration.bk_app_code,
+        applicant=configuration.bk_app_code,
         gateway_name="test1",
         grant_dimension="gateway",
     )
     mock_manager.apply_permission.assert_any_call(
         target_app_code=configuration.bk_app_code,
+        applicant=configuration.bk_app_code,
         gateway_name="test2",
         grant_dimension="resource",
         resource_names=["get_user"],
     )
     mock_manager.apply_permission.assert_any_call(
         target_app_code=configuration.bk_app_code,
+        applicant="admin",
         gateway_name="test3",
         grant_dimension="api",
     )

--- a/sdks/apigw-manager/tests/apigw_manager/apigw/management/commands/test_create_version_and_release_apigw.py
+++ b/sdks/apigw-manager/tests/apigw_manager/apigw/management/commands/test_create_version_and_release_apigw.py
@@ -198,7 +198,10 @@ class TestHandle:
         definition_file.write(yaml.dump(fake_resource_version))
         stage = faker.pystr()
 
-        fetcher.latest_resource_version.return_value = fake_resource_version
+        fetcher.latest_resource_version.return_value = {
+            "id": 1,
+            "version": fake_resource_version["version"],
+        }
         releaser.release.return_value = {
             "version": fake_resource_version["version"],
             "resource_version_name": fake_resource_version["name"],
@@ -211,7 +214,7 @@ class TestHandle:
         releaser.create_resource_version.assert_not_called()
         releaser.release.assert_called_once_with(
             version=fake_resource_version["version"],
-            comment=fake_resource_version["comment"],
+            comment="",
             stage_names=stage,
         )
 
@@ -229,7 +232,12 @@ class TestHandle:
         definition_file.write(yaml.dump(fake_resource_version))
         stage = faker.pystr()
         fetcher.latest_resource_version.return_value = fake_resource_version
-        fetcher.list_resource_versions.return_value = {"count": 1}
+        fetcher.list_resource_versions.return_value = [
+            {
+                "version": fake_resource_version["version"],
+                "comment": fake_resource_version["comment"],
+            }
+        ]
 
         current_version = command._get_version_to_be_created(parse_version(fake_resource_version["version"]), True)
 
@@ -239,8 +247,8 @@ class TestHandle:
             "stage_names": [stage],
         }
         releaser.create_resource_version.return_value = {
+            "id": 1,
             "version": str(current_version),
-            "comment": fake_resource_version["comment"],
         }
         resource_sync_manager.is_dirty.return_value = True
 
@@ -252,7 +260,7 @@ class TestHandle:
         )
         releaser.release.assert_called_once_with(
             version=str(current_version),
-            comment=fake_resource_version["comment"],
+            comment="",
             stage_names=stage,
         )
 
@@ -279,10 +287,12 @@ class TestHandle:
 
         latest_version = "1.0.0-alpha1"
         fetcher.latest_resource_version.return_value = dict(fake_resource_version, version=latest_version)
-        fetcher.list_resource_versions.return_value = {"count": 0}
+        fetcher.list_resource_versions.return_value = []
 
         releaser.create_resource_version.return_value = dict(
-            fake_resource_version,
+            {
+                "id": 1,
+            },
             version=defined_version,
         )
         stage = faker.pystr()
@@ -294,7 +304,7 @@ class TestHandle:
         )
         releaser.release.assert_any_call(
             version=defined_version,
-            comment=fake_resource_version["comment"],
+            comment="",
             stage_names=stage,
         )
 
@@ -320,7 +330,12 @@ class TestHandle:
 
         stage = faker.pystr()
         fetcher.latest_resource_version.return_value = fake_resource_version
-        fetcher.list_resource_versions.return_value = {"count": 1}
+        fetcher.list_resource_versions.return_value = [
+            {
+                "version": "0.0.1",
+                "comment": fake_resource_version["comment"],
+            }
+        ]
 
         defined_version = command._get_version_to_be_created(parse_version("0.0.1"), True)
 
@@ -331,8 +346,8 @@ class TestHandle:
         }
 
         releaser.create_resource_version.return_value = {
+            "id": 1,
             "version": str(defined_version),
-            "comment": fake_resource_version["comment"],
         }
 
         resource_sync_manager.is_dirty.return_value = False
@@ -344,7 +359,7 @@ class TestHandle:
         )
         releaser.release.assert_called_once_with(
             version=str(defined_version),
-            comment=fake_resource_version["comment"],
+            comment="",
             stage_names=stage,
         )
 

--- a/sdks/apigw-manager/tests/apigw_manager/apigw/management/commands/test_sync_apigw_stage_mcp_servers.py
+++ b/sdks/apigw-manager/tests/apigw_manager/apigw/management/commands/test_sync_apigw_stage_mcp_servers.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# TencentBlueKing is pleased to support the open source community by making
+# 蓝鲸智云 - PaaS 平台 (BlueKing - PaaS System) available.
+# Copyright (C) Tencent. All rights reserved.
+# Licensed under the MIT License (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+#     http://opensource.org/licenses/MIT
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We undertake not to change the open source license (MIT license) applicable
+# to the current version of the project delivered to anyone in the future.
+
+import pytest
+
+from apigw_manager.apigw.management.commands.sync_apigw_stage_mcp_servers import Command
+
+
+@pytest.fixture()
+def command():
+    return Command()
+
+
+def test_do_uses_v2_result_data_directly(mock_manager, command, capsys):
+    stage_definition = {
+        "name": "prod",
+        "mcp_servers": [
+            {
+                "name": "demo",
+                "description": "demo",
+                "resource_names": ["get_user"],
+                "status": "active",
+            }
+        ],
+    }
+    mock_manager.sync_stage_mcp_servers.return_value = [
+        {"id": 1, "name": "gateway-prod-demo", "action": "create"},
+        {"id": 2, "name": "gateway-prod-demo-2", "action": "update"},
+    ]
+
+    command.do(mock_manager, [stage_definition])
+
+    mock_manager.sync_stage_mcp_servers.assert_called_once_with(**stage_definition)
+    captured = capsys.readouterr()
+    assert (
+        "API gateway stage mcp servers synchronization completed [ id:1,name:gateway-prod-demo,action:create ]"
+        in captured.out
+    )
+    assert (
+        "API gateway stage mcp servers synchronization completed [ id:2,name:gateway-prod-demo-2,action:update ]"
+        in captured.out
+    )
+
+
+def test_do_ignores_empty_v2_result(mock_manager, command, capsys):
+    stage_definition = {
+        "name": "prod",
+        "mcp_servers": [],
+    }
+    mock_manager.sync_stage_mcp_servers.return_value = []
+
+    command.do(mock_manager, [stage_definition])
+
+    mock_manager.sync_stage_mcp_servers.assert_called_once_with(**stage_definition)
+    captured = capsys.readouterr()
+    assert captured.out == ""

--- a/sdks/apigw-manager/tests/apigw_manager/core/test_hander.py
+++ b/sdks/apigw-manager/tests/apigw_manager/core/test_hander.py
@@ -18,7 +18,7 @@
 import pytest
 from faker import Faker
 
-from apigw_manager.core.exceptions import ApiResponseError
+from apigw_manager.core.exceptions import ApiResponseError, ApiResultError
 from apigw_manager.core.handler import Handler
 from bkapi_client_core.exceptions import HTTPResponseError
 
@@ -74,58 +74,76 @@ class TestHandler:
 
         assert handler._put_into_cache(operation_id, api_data, {})
 
-    def test_call_with_cache(self, handler: Handler, operation, operation_id, faker, mocker):
-        result = faker.pydict()
-        operation.return_value = result
-        mock_get_from_cache = mocker.patch.object(Handler, "_get_from_cache", return_value=(False, None))
-        mock_put_into_cache = mocker.patch.object(Handler, "_put_into_cache", return_value=None)
-
-        gateway_name = faker.pystr()
-        kwargs = {
-            "gateway_name": gateway_name,
-            "foo": "bar",
-        }
-
-        handler._call_with_cache(operation, **kwargs)
-
-        cache_key = {
-            "gateway_name": gateway_name,
-            "kwargs": {"gateway_name": gateway_name, "foo": "bar"},
-        }
-        mock_get_from_cache.assert_called_once_with(operation_id, cache_key)
-        mock_put_into_cache.assert_called_once_with(operation_id, cache_key, result)
-
-    def test_call_connect_error(self, handler: Handler, operation):
-        operation.side_effect = HTTPResponseError()
-        with pytest.raises(ApiResponseError):
-            handler._call(operation)
-
-    def test_call_server_error(self, handler: Handler, operation, mocker):
-        operation.side_effect = HTTPResponseError(response=mocker.MagicMock(status_code=500))
-        with pytest.raises(ApiResponseError):
-            handler._call(operation)
-
-    def test_call_request_error(self, handler: Handler, operation, mocker):
+    def test_call_v2_request_error_parse_error_body(self, handler: Handler, operation, mocker):
+        operation.path = "/api/v2/sync/gateways/{gateway_name}/"
         operation.side_effect = HTTPResponseError(
             response=mocker.MagicMock(
                 status_code=400,
-                json=mocker.MagicMock(return_value={"code": "400", "message": "request error"}),
+                json=mocker.MagicMock(
+                    return_value={
+                        "error": {
+                            "code": "AuthFailure",
+                            "message": "The provided credentials could not be validated.",
+                            "system": "bkiam",
+                            "details": [
+                                {
+                                    "code": "SignatureFailure",
+                                    "message": "",
+                                    "module": "auth",
+                                    "links": "",
+                                    "doc": "",
+                                }
+                            ],
+                            "data": {},
+                        }
+                    }
+                ),
             )
         )
 
-        with pytest.raises(ApiResponseError):
-            handler._call(operation)
+        with pytest.raises(ApiResultError) as err:
+            handler._call_v2(operation)
 
-    def test_call_request_error_with_no_json(self, handler: Handler, operation, mocker):
+        assert err.value.code == "AuthFailure"
+        assert err.value.message == "The provided credentials could not be validated."
+
+    def test_call_v2_request_error_with_no_json(self, handler: Handler, operation, mocker):
+        operation.path = "/api/v2/sync/gateways/{gateway_name}/"
         operation.side_effect = HTTPResponseError(
             response=mocker.MagicMock(
-                status_code=400,
+                status_code=500,
+                text="server error",
                 json=mocker.MagicMock(side_effect=ValueError()),
             )
         )
 
-        with pytest.raises(ApiResponseError):
-            handler._call(operation)
+        with pytest.raises(ApiResultError) as err:
+            handler._call_v2(operation)
+
+        assert err.value.code == 500
+        assert err.value.message == "server error"
+
+    def test_call_v2_connect_error(self, handler: Handler, operation):
+        operation.path = "/api/v2/sync/gateways/{gateway_name}/"
+        operation.side_effect = HTTPResponseError()
+
+        with pytest.raises(ApiResponseError) as err:
+            handler._call_v2(operation)
+
+        assert not isinstance(err.value, ApiResultError)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            {},
+            [],
+            {"id": 1, "name": "gateway"},
+        ],
+    )
+    def test_parse_v2_result_returns_data_for_success_response(self, handler: Handler, data):
+        result = {"data": data}
+
+        assert handler._parse_v2_result(result) == data
 
     def test_get_tenant_id_from_config(self, handler: Handler, mocker):
         handler.config.bk_app_tenant_id = "123"

--- a/sdks/apigw-manager/tests/apigw_manager/core/test_utils.py
+++ b/sdks/apigw-manager/tests/apigw_manager/core/test_utils.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from apigw_manager.core.utils import get_item, itemgetter
+from apigw_manager.core.utils import get_item
 
 
 @pytest.fixture()
@@ -41,9 +41,3 @@ class TestGetItem:
 
         with pytest.raises(KeyError):
             get_item(test_data, ["a", "nothing"])
-
-
-class TestItemGetter:
-    def test_usage(self, test_data):
-        getter = itemgetter("a", "color")
-        assert getter(test_data) == test_data["a"]["color"]


### PR DESCRIPTION
## Summary
- Release `apigw-manager` as `5.0.1` and add the corresponding changelog entry.
- Add a v2 response parser for `apigw-manager` so successful 20x v2 responses return the `data` field directly, including `{}` and `[]` payloads.
- Parse non-20x v2 API responses from the `error` body into `ApiResultError`, with a status/text fallback for non-JSON responses.
- Switch core v2 sync/fetch/release/permission calls to the v2 parser and add regression coverage for success, error-body, non-JSON, and connection-error cases.
- Update resource-version existence checks to use the v2 list response shape instead of the legacy `count` envelope.
- Stop reading `comment` from v2 resource-version responses when releasing; created/latest resource-version payloads are treated as id/version-only and release comment defaults to an empty string unless passed explicitly.
- Update stage MCP server sync output handling to consume the v2 `data` list directly instead of unwrapping a legacy `data` envelope again.
- Add the required v2 `applicant` field when applying gateway permissions, while preserving explicit applicant values from definitions.
- Remove v1-only private helpers and tests left unused after the v2 upgrade: `_call`, `_call_with_cache`, `_parse_result`, and `itemgetter`.

## Verification
- `PYENV_VERSION=apigw-manager poetry check` -> passed with existing metadata warnings
- `PYENV_VERSION=apigw-manager PYTHONPATH=src poetry run pytest -q --ds demo.settings tests/apigw_manager/apigw/management/commands/test_create_version_and_release_apigw.py -q` -> 29 passed
- `PYENV_VERSION=apigw-manager PYTHONPATH=src poetry run pytest -q --ds demo.settings tests/apigw_manager/apigw/management/commands/test_apply_apigw_permissions.py -q` -> 1 passed
- `PYENV_VERSION=apigw-manager PYTHONPATH=src poetry run pytest -q --ds demo.settings tests/apigw_manager/apigw/management/commands/test_sync_apigw_stage_mcp_servers.py -q` -> 2 passed
- `PYENV_VERSION=apigw-manager PYTHONPATH=src poetry run pytest -q --ds demo.settings tests/apigw_manager/apigw/management/commands -q` -> 42 passed
- `PYENV_VERSION=apigw-manager PYTHONPATH=src poetry run pytest -q --ds demo.settings tests/apigw_manager/core -q` -> 15 passed
- `PYENV_VERSION=apigw-manager make test` -> 274 passed
- `PYENV_VERSION=apigw-manager poetry run mypy src/apigw_manager/apigw/management/commands/create_version_and_release_apigw.py tests/apigw_manager/apigw/management/commands/test_create_version_and_release_apigw.py` -> no issues found in 2 source files
- `PYENV_VERSION=apigw-manager poetry run mypy src/apigw_manager/apigw/management/commands/apply_apigw_permissions.py tests/apigw_manager/apigw/management/commands/test_apply_apigw_permissions.py` -> no issues found in 2 source files
- `PYENV_VERSION=apigw-manager poetry run mypy src/apigw_manager/apigw/management/commands/sync_apigw_stage_mcp_servers.py tests/apigw_manager/apigw/management/commands/test_sync_apigw_stage_mcp_servers.py` -> no issues found in 2 source files
- `PYENV_VERSION=apigw-manager poetry run mypy src/apigw_manager/core tests/apigw_manager/core` -> no issues found in 13 source files
- `git diff --check` / `git diff --cached --check` -> passed
- `PYENV_VERSION=apigw-manager make lint` -> failed: no `lint` target in `sdks/apigw-manager/Makefile` or included parent Makefile
- `PYENV_VERSION=apigw-manager poetry run mypy src` -> failed on existing errors in untouched files: `src/apigw_manager/drf/utils.py`, `src/apigw_manager/drf/management/commands/generate_resources_yaml.py`, and `src/apigw_manager/plugin/config.py`