### PR TITLE
fix: connect_to_django_user drops time_zone, breaking UserTimezoneMiddleware

### DIFF
--- a/sdks/bkpaas-auth/CHANGES.md
+++ b/sdks/bkpaas-auth/CHANGES.md
@@ -1,5 +1,9 @@
 # 版本历史
 
+## 4.1.1
+
+- fix: 修复 DjangoAuthUserCompatibleBackend 未传递 time_zone 字段的问题
+
 ## 4.1.0
 
 - 支持 python 3.14

--- a/sdks/bkpaas-auth/bkpaas_auth/__init__.py
+++ b/sdks/bkpaas-auth/bkpaas_auth/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 
 def get_user_by_user_id(user_id: str, username_only: bool = True):

--- a/sdks/bkpaas-auth/bkpaas_auth/backends.py
+++ b/sdks/bkpaas-auth/bkpaas_auth/backends.py
@@ -184,6 +184,7 @@ class DjangoAuthUserCompatibleBackend(UniversalAuthBackend):
             db_user.token = user.token
             db_user.display_name = getattr(user, "display_name", user.username)
             db_user.tenant_id = getattr(user, "tenant_id", None)
+            db_user.time_zone = getattr(user, "time_zone", None)
 
         return db_user
 

--- a/sdks/bkpaas-auth/pyproject.toml
+++ b/sdks/bkpaas-auth/pyproject.toml
@@ -5,7 +5,7 @@ classifiers = ["License :: OSI Approved :: MIT License"]
 # PEP 621 project metadata
 # See https://www.python.org/dev/peps/pep-0621/
 name = "bkpaas-auth"
-version = "4.1.0"
+version = "4.1.1"
 description = "User authentication django app for blueking internal projects"
 readme = "README.md"
 authors = [{ name = "blueking", email = "blueking@tencent.com" }]

--- a/sdks/bkpaas-auth/tests/test_middlewares.py
+++ b/sdks/bkpaas-auth/tests/test_middlewares.py
@@ -188,6 +188,32 @@ class TestCookieLoginMiddlewareWithDjangoUser:
         assert not isinstance(user, User)
         assert isinstance(user.pk, int)
 
+    @override_settings(
+        AUTHENTICATION_BACKENDS=["bkpaas_auth.backends.DjangoAuthUserCompatibleBackend"],
+        TIME_ZONE="UTC",
+    )
+    def test_time_zone_propagated_to_django_user(self, db, bk_token, dj_request):
+        """time_zone should survive connect_to_django_user."""
+        middleware = CookieLoginMiddleware(MagicMock())
+        dj_request.COOKIES["bk_token"] = bk_token
+
+        # Create a bkpaas_auth User with time_zone
+        user = create_uin_user(bk_token)
+        user.time_zone = "Asia/Shanghai"
+
+        with patch("bkpaas_auth.backends.UniversalAuthBackend.authenticate") as mocked_authenticate:
+            mocked_authenticate.return_value = user
+            middleware(dj_request)
+
+        # time_zone should be propagated from bkpaas_auth.User to Django AuthUser
+        assert getattr(dj_request.user, "time_zone", None) == "Asia/Shanghai"
+
+        # UserTimezoneMiddleware should activate the timezone
+        tz_middleware = UserTimezoneMiddleware(MagicMock())
+        dj_timezone.deactivate()
+        tz_middleware.process_request(dj_request)
+        assert dj_timezone.get_current_timezone_name() == "Asia/Shanghai"
+
 
 class TestUserTimezoneMiddleware:
     """Test cases for UserTimezoneMiddleware"""


### PR DESCRIPTION
Related issues: #301 
